### PR TITLE
Setgray

### DIFF
--- a/content_obj.go
+++ b/content_obj.go
@@ -122,7 +122,7 @@ func (me *ContentObj) AppendStreamSetLineWidth(w float64) {
 
 }
 
-//  Set the grayscale fill
+//  Set the grayscale fills
 func (me *ContentObj) AppendStreamSetGrayFill(w float64) {
 	me.stream.WriteString(fmt.Sprintf("%.2f g\n", w))
 }

--- a/content_obj.go
+++ b/content_obj.go
@@ -124,11 +124,13 @@ func (me *ContentObj) AppendStreamSetLineWidth(w float64) {
 
 //  Set the grayscale fills
 func (me *ContentObj) AppendStreamSetGrayFill(w float64) {
+	w = fixRange10(w)
 	me.stream.WriteString(fmt.Sprintf("%.2f g\n", w))
 }
 
 //  Set the grayscale stroke
 func (me *ContentObj) AppendStreamSetGrayStroke(w float64) {
+	w = fixRange10(w)
 	me.stream.WriteString(fmt.Sprintf("%.2f G\n", w))
 }
 
@@ -141,4 +143,17 @@ func (me *ContentObj) AppendStreamImage(index int, x float64, y float64, rect *R
 //cal text height
 func ContentObj_CalTextHeight(fontsize int) float64 {
 	return (float64(fontsize) * 0.7)
+}
+
+// When setting colour and grayscales the value has to be between 0.00 and 1.00
+// This function takes a float64 and returns 0.0 if it is less than 0.0 and 1.0 if it
+// is more than 1.0
+func fixRange10(val float64) float64 {
+	if val < 0.0 {
+		return 0.0
+	}
+	if val > 1.0 {
+		return 1.0
+	}
+	return val
 }

--- a/content_obj.go
+++ b/content_obj.go
@@ -122,6 +122,16 @@ func (me *ContentObj) AppendStreamSetLineWidth(w float64) {
 
 }
 
+//  Set the grayscale fill
+func (me *ContentObj) AppendStreamSetGrayFill(w float64) {
+	me.stream.WriteString(fmt.Sprintf("%.2f g\n", w))
+}
+
+//  Set the grayscale stroke
+func (me *ContentObj) AppendStreamSetGrayStroke(w float64) {
+	me.stream.WriteString(fmt.Sprintf("%.2f G\n", w))
+}
+
 func (me *ContentObj) AppendStreamImage(index int, x float64, y float64, rect *Rect) {
 	//fmt.Printf("index = %d",index)
 	h := me.getRoot().config.PageSize.H

--- a/gopdf.go
+++ b/gopdf.go
@@ -57,6 +57,18 @@ func (gp *GoPdf) Br(h float64) {
 	gp.Curr.X = gp.leftMargin
 }
 
+// Set the grayscale for the fill, takes a float64 between 0.0 and 1.0
+func (gp *GoPdf) SetGrayFill(grayScale float64) {
+	grayScale = colourValueCheck(grayScale)
+	gp.getContent().AppendStreamSetGrayFill(grayScale)
+}
+
+// Set the grayscale for the stroke, takes a float64 between 0.0 and 1.0
+func (gp *GoPdf) SetGrayStroke(grayScale float64) {
+	grayScale = colourValueCheck(grayScale)
+	gp.getContent().AppendStreamSetGrayStroke(grayScale)
+}
+
 //SetLeftMargin : set left margin
 func (gp *GoPdf) SetLeftMargin(margin float64) {
 	gp.leftMargin = margin

--- a/gopdf.go
+++ b/gopdf.go
@@ -59,13 +59,11 @@ func (gp *GoPdf) Br(h float64) {
 
 // Set the grayscale for the fill, takes a float64 between 0.0 and 1.0
 func (gp *GoPdf) SetGrayFill(grayScale float64) {
-	grayScale = colourValueCheck(grayScale)
 	gp.getContent().AppendStreamSetGrayFill(grayScale)
 }
 
 // Set the grayscale for the stroke, takes a float64 between 0.0 and 1.0
 func (gp *GoPdf) SetGrayStroke(grayScale float64) {
-	grayScale = colourValueCheck(grayScale)
 	gp.getContent().AppendStreamSetGrayStroke(grayScale)
 }
 


### PR DESCRIPTION
Added the setgray directive. It allows you to set the gray scale level for a stroke or a fill.

SetGrayFill sets the grayscale for the Fill and SetGrayStroke sets the grayscale for the stroke. Both of them take a single parameter of a float64 between 0.00 and 1.00 of the desired grayscale.

Also added a function called fixRange10 which takes a float64 and ensures it is between 0.0 and 1.0 for the setgray directive. It is also there for future color directives.

Usage:
    pdf.SetGrayFill(0.5)
    pdf.SetGrayStroke(0.1)