### PR TITLE
Add function SetLineType

### DIFF
--- a/content_obj.go
+++ b/content_obj.go
@@ -177,6 +177,20 @@ func (c *ContentObj) AppendStreamSetLineWidth(w float64) {
 
 }
 
+// AppendStreamSetLineType : Set linetype [solid, dashed, dotted]
+func (c *ContentObj) AppendStreamSetLineType(t string) {
+	switch t {
+	case "dashed":
+		c.stream.WriteString(fmt.Sprint("[5] 2 d\n"))
+	case "dotted":
+		c.stream.WriteString(fmt.Sprint("[2 3] 11 d\n"))
+	default:
+		c.stream.WriteString(fmt.Sprint("[] 0 d\n"))
+	}
+
+
+}
+
 //  Set the grayscale fills
 func (c *ContentObj) AppendStreamSetGrayFill(w float64) {
 	w = fixRange10(w)

--- a/gopdf.go
+++ b/gopdf.go
@@ -46,6 +46,11 @@ func (gp *GoPdf) SetLineWidth(width float64) {
 	gp.getContent().AppendStreamSetLineWidth(width)
 }
 
+//SetLineType : set line type
+func (gp *GoPdf) SetLineType(linetype string) {
+	gp.getContent().AppendStreamSetLineType(linetype)
+}
+
 //Line : draw line
 func (gp *GoPdf) Line(x1 float64, y1 float64, x2 float64, y2 float64) {
 	gp.getContent().AppendStreamLine(x1, y1, x2, y2)


### PR DESCRIPTION
Reference : [8.4.3.6 Line Dash Pattern](http://wwwimages.adobe.com/content/dam/Adobe/en/devnet/pdf/pdfs/PDF32000_2008.pdf)

Usage:
```
pdf.SetLineType("dashed")
pdf.Line(50, 200, 550, 200)
pdf.SetLineType("dotted")
pdf.Line(50, 400, 550, 400)
```