### PR TITLE
adding draw rectangle...

### DIFF
--- a/content_obj.go
+++ b/content_obj.go
@@ -127,6 +127,12 @@ func (c *ContentObj) AppendStreamLine(x1 float64, y1 float64, x2 float64, y2 flo
 	c.stream.WriteString(fmt.Sprintf("%0.2f %0.2f m %0.2f %0.2f l s\n", x1, h-y1, x2, h-y2))
 }
 
+//AppendStreamRectangle : draw rectangle from lower-left corner (x, y) with specif width/height
+func (c *ContentObj) AppendStreamRectangle(x float64, y float64, wdth float64, hght float64) {
+	h := c.getRoot().config.PageSize.H
+	c.stream.WriteString(fmt.Sprintf("%0.2f %0.2f %0.2f %0.2f re s\n", x, h-y, wdth, hght))
+}
+
 func (c *ContentObj) AppendStreamOval(x1 float64, y1 float64, x2 float64, y2 float64) {
 	h := c.getRoot().config.PageSize.H
 	cp := 0.55228                              // Magnification of the control point

--- a/gopdf.go
+++ b/gopdf.go
@@ -61,6 +61,16 @@ func (gp *GoPdf) Line(x1 float64, y1 float64, x2 float64, y2 float64) {
 	gp.getContent().AppendStreamLine(x1, y1, x2, y2)
 }
 
+//RectFromLowerLeft : draw rectangle from lower-left corner (x, y)
+func (gp *GoPdf) RectFromLowerLeft(x float64, y float64, wdth float64, hght float64) {
+	gp.getContent().AppendStreamRectangle(x, y, wdth, hght)
+}
+
+//RectFromUpperLeft : draw rectangle from upper-left corner (x, y)
+func (gp *GoPdf) RectFromUpperLeft(x float64, y float64, wdth float64, hght float64) {
+	gp.getContent().AppendStreamRectangle(x, y+hght, wdth, hght)
+}
+
 //Oval : draw oval
 func (gp *GoPdf) Oval(x1 float64, y1 float64, x2 float64, y2 float64) {
 	gp.getContent().AppendStreamOval(x1, y1, x2, y2)


### PR DESCRIPTION
I've added two functions for drawing a rectangle:
RectFromUpperLeft(...) and RectFromLowerLeft(..)
but I think only one of them should go to the master and with a simpler name (for example just Rect() or Rectangle() )
Two because it's common in gopdf to draw from upper-left corner, but in PDF specification rectangle goes from lower-left. I don't know what is better here.