### PR TITLE
Fix xref

### DIFF
--- a/gopdf.go
+++ b/gopdf.go
@@ -701,12 +701,12 @@ func (gp *GoPdf) xref(linelens []int, buff *bytes.Buffer, i *int) error {
 	xrefbyteoffset := buff.Len()
 	buff.WriteString("xref\n")
 	buff.WriteString("0 " + strconv.Itoa((*i)+1) + "\n")
-	buff.WriteString("0000000000 65535 f\n")
+	buff.WriteString("0000000000 65535 f \n")
 	j := 0
 	max := len(linelens)
 	for j < max {
 		linelen := linelens[j]
-		buff.WriteString(gp.formatXrefline(linelen) + " 00000 n\n")
+		buff.WriteString(gp.formatXrefline(linelen) + " 00000 n \n")
 		j++
 	}
 	buff.WriteString("trailer\n")


### PR DESCRIPTION
PDF_reference_1_7.pdf, section "3.4.3 Cross-Reference Table": 
[...] Each entry is exactly 20 bytes long, including the end-of-line marker. [...]
The format of an in-use entry is
   nnnnnnnnnn ggggg n eol
   where [...] eol is a 2-character end-of-line sequence