### PR TITLE
Add support to load fonts with same family name but different styles

### DIFF
--- a/cache_content_text.go
+++ b/cache_content_text.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 )
 
 //ContentTypeCell cell
@@ -21,7 +20,7 @@ type cacheContentText struct {
 	grayFill       float64
 	fontCountIndex int //Curr.Font_FontCount+1
 	fontSize       int
-	fontStyle      string
+	fontStyle      int
 	setXCount      int //จำนวนครั้งที่ใช้ setX
 	x, y           float64
 	fontSubset     *SubsetFontObj
@@ -143,7 +142,7 @@ func (c *cacheContentText) toStream(protection *PDFProtection) (*bytes.Buffer, e
 	stream.WriteString("[<" + c.content.String() + ">] TJ\n")
 	stream.WriteString("ET\n")
 
-	if strings.ToUpper(c.fontStyle) == "U" {
+	if c.fontStyle&Underline == Underline {
 		underlineStream, err := c.underline(c.x, c.y, c.x+c.cellWidthPdfUnit, c.y)
 		if err != nil {
 			return nil, err
@@ -327,7 +326,7 @@ func (c *CacheContent) Setup(rectangle *Rect,
 	grayFill float64,
 	fontCountIndex int, //Curr.Font_FontCount+1
 	fontSize int,
-	fontStyle string,
+	fontStyle int,
 	setXCount int, //จำนวนครั้งที่ใช้ setX
 	x, y float64,
 	fontSubset *SubsetFontObj,

--- a/current.go
+++ b/current.go
@@ -12,7 +12,7 @@ type Current struct {
 	CountOfL       int
 
 	Font_Size      int
-	Font_Style     string
+	Font_Style     int // Regular|Bold|Italic|Underline
 	Font_FontCount int
 	Font_Type      int // CURRENT_FONT_TYPE_IFONT or  CURRENT_FONT_TYPE_SUBSET
 

--- a/font_option.go
+++ b/font_option.go
@@ -1,0 +1,28 @@
+package gopdf
+
+import (
+	"strings"
+)
+
+//Regular - font style regular
+const Regular = 0 //000000
+//Italic - font style italic
+const Italic = 1 //000001
+//Bold - font style bold
+const Bold = 2 //000010
+//Underline - font style underline
+const Underline = 4 //000100
+
+func getConvertedStyle(fontStyle string) (style int) {
+	fontStyle  = strings.ToUpper(fontStyle)
+	if strings.Contains(fontStyle, "B") {
+		style=style|Bold
+	}
+	if strings.Contains(fontStyle, "I") {
+		style=style|Italic
+	}
+	if strings.Contains(fontStyle, "U"){
+		style=style|Underline
+	}
+	return
+}

--- a/procset_obj.go
+++ b/procset_obj.go
@@ -69,12 +69,26 @@ func (re *RelateFonts) IsContainsFamily(family string) bool {
 	return false
 }
 
+// IsContainsFamilyAndStyle - checks if already exists font with same name and style
+func (re *RelateFonts) IsContainsFamilyAndStyle(family string, style int) bool {
+	i := 0
+	max := len(*re)
+	for i < max {
+		if (*re)[i].Family == family && (*re)[i].Style == style  {
+			return true
+		}
+		i++
+	}
+	return false
+}
+
 type RelateFont struct {
 	Family string
 	//etc /F1
 	CountOfFont int
 	//etc  5 0 R
 	IndexOfObj int
+	Style      int // Regular|Bold|Italic
 }
 
 type RealteXobjects []RealteXobject

--- a/subset_font_obj.go
+++ b/subset_font_obj.go
@@ -69,6 +69,11 @@ func (s *SubsetFontObj) SetTtfFontOption(option TtfOption) {
 	s.ttfFontOption = option
 }
 
+//GetTtfFontOption get TtfOption must set before SetTTFByPath
+func (s *SubsetFontObj) GetTtfFontOption() TtfOption {
+	return s.ttfFontOption
+}
+
 //KernValueByLeft find kern value from kern table by left
 func (s *SubsetFontObj) KernValueByLeft(left uint) (bool, *core.KernValue) {
 

--- a/ttf_option.go
+++ b/ttf_option.go
@@ -3,10 +3,12 @@ package gopdf
 //TtfOption  font option
 type TtfOption struct {
 	UseKerning bool
+	Style      int // Regular|Bold|Italic
 }
 
 func defaultTtfFontOption() TtfOption {
 	var defa TtfOption
 	defa.UseKerning = false
+	defa.Style = Regular
 	return defa
 }


### PR DESCRIPTION
New `Style` field to `TTFOption` wich adds ability to load many fonts with same family name but different styles
ie: Regular, Bold, Italic, Bold|Italic

One of the goals is to make support for HTML element (custom or maybe builtin) that can have text with bold/italic tags

