### PR TITLE
Use bytes.Equal(), remove CompareBytes()

### DIFF
--- a/fontmaker/core/ttfparser.go
+++ b/fontmaker/core/ttfparser.go
@@ -74,7 +74,7 @@ type TTFParser struct {
 	groupingTables []CmapFormat12GroupingTable
 
 	//data of font
-	cahceFontData []byte
+	cacheFontData []byte
 
 	//kerning
 	useKerning bool //user config for use or not use kerning
@@ -224,14 +224,14 @@ func (t *TTFParser) parse(rd io.Reader) error {
 	if err != nil {
 		return err
 	}
-	//t.cahceFontData = fontdata
+	//t.cacheFontData = fontdata
 	fd := bytes.NewReader(fontdata)
 
 	version, err := t.Read(fd, 4)
 	if err != nil {
 		return err
 	}
-	if !t.CompareBytes(version, []byte{0x00, 0x01, 0x00, 0x00}) {
+	if !bytes.Equal(version, []byte{0x00, 0x01, 0x00, 0x00}) {
 		return errors.New("Unrecognized file (font) format")
 	}
 
@@ -323,13 +323,13 @@ func (t *TTFParser) parse(rd io.Reader) error {
 	}
 
 	//fmt.Printf("%#v\n", me.widths)
-	t.cahceFontData = fontdata //t.readFontData(fontpath)
+	t.cacheFontData = fontdata //t.readFontData(fontpath)
 
 	return nil
 }
 
 func (t *TTFParser) FontData() []byte {
-	return t.cahceFontData
+	return t.cacheFontData
 }
 
 //ParseLoca parse loca table https://www.microsoft.com/typography/otspec/loca.htm
@@ -1044,30 +1044,4 @@ func (t *TTFParser) Read(fd *bytes.Reader, length int) ([]byte, error) {
 	}
 	//fmt.Printf("%d,%s\n", readlength, string(buff))
 	return buff, nil
-}
-
-//CompareBytes compare a and b
-func (t *TTFParser) CompareBytes(a []byte, b []byte) bool {
-
-	if a == nil && b == nil {
-		return true
-	} else if a == nil && b != nil {
-		return false
-	} else if a != nil && b == nil {
-		return false
-	}
-
-	if len(a) != len(b) {
-		return false
-	}
-
-	i := 0
-	length := len(a)
-	for i < length {
-		if a[i] != b[i] {
-			return false
-		}
-		i++
-	}
-	return true
 }

--- a/image_obj_parse.go
+++ b/image_obj_parse.go
@@ -133,7 +133,7 @@ func paesePng(f *bytes.Reader, info *imgInfo, imgConfig image.Config) error {
 	if err != nil {
 		return err
 	}
-	if !compareBytes(b, pngMagicNumber) {
+	if !bytes.Equal(b, pngMagicNumber) {
 		return errors.New("Not a PNG file")
 	}
 
@@ -142,7 +142,7 @@ func paesePng(f *bytes.Reader, info *imgInfo, imgConfig image.Config) error {
 	if err != nil {
 		return err
 	}
-	if !compareBytes(b, pngIHDR) {
+	if !bytes.Equal(b, pngIHDR) {
 		return errors.New("Incorrect PNG file")
 	}
 
@@ -429,30 +429,6 @@ func readBytes(f *bytes.Reader, len int) ([]byte, error) {
 		return nil, err
 	}
 	return b, nil
-}
-
-func compareBytes(a []byte, b []byte) bool {
-	if a == nil && b == nil {
-		return true
-	} else if a == nil {
-		return false
-	} else if b == nil {
-		return false
-	}
-
-	if len(a) != len(b) {
-		return false
-	}
-
-	i := 0
-	max := len(a)
-	for i < max {
-		if a[i] != b[i] {
-			return false
-		}
-		i++
-	}
-	return true
 }
 
 func isDeviceRGB(formatname string, img *image.Image) bool {


### PR DESCRIPTION
* bytes.Equal in the standard lib does the
  same thing as (t *TTFParser) CompareBytes()

* fix spelling of cacheFontData

in ./fontmaker/core/ttfparser.go