### PR TITLE
Improve WritePdf to return error from WriteFile

### DIFF
--- a/gopdf.go
+++ b/gopdf.go
@@ -382,8 +382,8 @@ func (gp *GoPdf) SetFont(family string, style string, size int) error {
 }
 
 //WritePdf : wirte pdf file
-func (gp *GoPdf) WritePdf(pdfPath string) {
-	ioutil.WriteFile(pdfPath, gp.GetBytesPdf(), 0644)
+func (gp *GoPdf) WritePdf(pdfPath string) error {
+	return ioutil.WriteFile(pdfPath, gp.GetBytesPdf(), 0644)
 }
 
 func (gp *GoPdf) Write(w io.Writer) error {


### PR DESCRIPTION
Changes signature of WritePdf to return the result of WriteFile so errors can be processed properly