### PR TITLE
When Draw Line, No Need Close Path, so use S NOT s

### DIFF
--- a/cache_content_line.go
+++ b/cache_content_line.go
@@ -14,6 +14,6 @@ type cacheContentLine struct {
 }
 
 func (c *cacheContentLine) write(w io.Writer, protection *PDFProtection) error {
-	fmt.Fprintf(w, "%0.2f %0.2f m %0.2f %0.2f l s\n", c.x1, c.pageHeight-c.y1, c.x2, c.pageHeight-c.y2)
+	fmt.Fprintf(w, "%0.2f %0.2f m %0.2f %0.2f l S\n", c.x1, c.pageHeight-c.y1, c.x2, c.pageHeight-c.y2)
 	return nil
 }


### PR DESCRIPTION
when use gopdf to draw some lines to make up a "table", the result PDF seems OK,
but if use some tools (in my OS, use Chrome Browser, in other people, use Adobe Reader) to Print to Physical Printer, it would go to lines crossed.
*You can see attached photo:

![img_2526](https://user-images.githubusercontent.com/33439192/48258165-7158e280-e44f-11e8-8e2c-297b76b009fd.jpg)