### PR TITLE
Added pagesizes as readable variables

### DIFF
--- a/page_sizes.go
+++ b/page_sizes.go
@@ -1,0 +1,23 @@
+package gopdf
+
+var PageSizeLetter = Rect{W: 612, H: 792}
+var PageSizeLetterSmall = Rect{W: 612, H: 792}
+var PageSizeTabloid = Rect{W: 792, H: 1224}
+var PageSizeLedger = Rect{W: 1224, H: 792}
+var PageSizeLegal = Rect{W: 612, H: 1008}
+var PageSizeStatement = Rect{W: 396, H: 612}
+var PageSizeExecutive = Rect{W: 540, H: 720}
+var PageSizeA0 = Rect{W: 2384, H: 3371}
+var PageSizeA1 = Rect{W: 1685, H: 2384}
+var PageSizeA2 = Rect{W: 1190, H: 1684}
+var PageSizeA3 = Rect{W: 842, H: 1190}
+var PageSizeA4 = Rect{W: 595, H: 842}
+var PageSizeA4Small = Rect{W: 595, H: 842}
+var PageSizeA5 = Rect{W: 420, H: 595}
+var PageSizeB4 = Rect{W: 729, H: 1032}
+var PageSizeB5 = Rect{W: 516, H: 729}
+var PageSizeFolio = Rect{W: 612, H: 936}
+var PageSizeQuarto = Rect{W: 610, H: 780}
+var PageSize10x14 = Rect{W: 720, H: 1008}
+
+// var PageSizeEnvelope	 = Rect{W:???,H:???}


### PR DESCRIPTION
### Goal

Better readable pagesize definition

### Usage

  	pdf.Start(gopdf.Config{PageSize: gopdf.PageSizeA4})

### Comment

I found it tedious defining the pagesizes by hand, and also tried to figure why you had floating for a4, maybe you could elaborate?
Also let me know if you feel this would be better placed elsewhere.

Cheers