### PR TITLE
 Add multiple lines Cell method with auto text wrapping

### DIFF
--- a/gopdf.go
+++ b/gopdf.go
@@ -523,11 +523,13 @@ func (gp *GoPdf) MultiCell(rectangle *Rect, text string) error {
 	length := len([]rune(text))
 
 	// get lineHeight
-	err := gp.curr.Font_ISubset.AddChars(text)
-	if err != nil {
+	if err := gp.curr.Font_ISubset.AddChars(text); err != nil {
 		return err
 	}
 	_, lineHeight, _, err := createContent(gp.curr.Font_ISubset, text, gp.curr.Font_Size, nil)
+	if err != nil {
+		return err
+	}
 
 	for i, v := range []rune(text) {
 		lineWidth, _ := gp.MeasureTextWidth(string(line))
@@ -546,6 +548,7 @@ func (gp *GoPdf) MultiCell(rectangle *Rect, text string) error {
 			gp.Br(lineHeight)
 		}
 	}
+	return nil
 }
 
 //AddLink

--- a/gopdf.go
+++ b/gopdf.go
@@ -520,6 +520,7 @@ func (gp *GoPdf) Cell(rectangle *Rect, text string) error {
 //MultiCell : create of text with line breaks ( use current x,y is upper-left corner of cell)
 func (gp *GoPdf) MultiCell(rectangle *Rect, text string) error {
 	var line []rune
+	x := gp.GetX()
 	var totalLineHeight float64
 	length := len([]rune(text))
 
@@ -542,6 +543,7 @@ func (gp *GoPdf) MultiCell(rectangle *Rect, text string) error {
 		if lineWidth+runeWidth > rectangle.W {
 			gp.Cell(&Rect{W: rectangle.W, H: lineHeight}, string(line))
 			gp.Br(lineHeight)
+			gp.SetX(x)
 			totalLineHeight = totalLineHeight + lineHeight
 			line = nil
 		}
@@ -551,6 +553,7 @@ func (gp *GoPdf) MultiCell(rectangle *Rect, text string) error {
 		if i == length-1 {
 			gp.Cell(&Rect{W: rectangle.W, H: lineHeight}, string(line))
 			gp.Br(lineHeight)
+			gp.SetX(x)
 		}
 	}
 	return nil

--- a/gopdf.go
+++ b/gopdf.go
@@ -520,6 +520,7 @@ func (gp *GoPdf) Cell(rectangle *Rect, text string) error {
 //MultiCell : create of text with line breaks ( use current x,y is upper-left corner of cell)
 func (gp *GoPdf) MultiCell(rectangle *Rect, text string) error {
 	var line []rune
+	var totalLineHeight float64
 	length := len([]rune(text))
 
 	// get lineHeight
@@ -532,12 +533,16 @@ func (gp *GoPdf) MultiCell(rectangle *Rect, text string) error {
 	}
 
 	for i, v := range []rune(text) {
+		if totalLineHeight+lineHeight > rectangle.H {
+			break
+		}
 		lineWidth, _ := gp.MeasureTextWidth(string(line))
 		runeWidth, _ := gp.MeasureTextWidth(string(v))
 
 		if lineWidth+runeWidth > rectangle.W {
 			gp.Cell(&Rect{W: rectangle.W, H: lineHeight}, string(line))
 			gp.Br(lineHeight)
+			totalLineHeight = totalLineHeight + lineHeight
 			line = nil
 		}
 

--- a/gopdf.go
+++ b/gopdf.go
@@ -517,6 +517,37 @@ func (gp *GoPdf) Cell(rectangle *Rect, text string) error {
 	return nil
 }
 
+//MultiCell : create of text with line breaks ( use current x,y is upper-left corner of cell)
+func (gp *GoPdf) MultiCell(rectangle *Rect, text string) error {
+	var line []rune
+	length := len([]rune(text))
+
+	// get lineHeight
+	err := gp.curr.Font_ISubset.AddChars(text)
+	if err != nil {
+		return err
+	}
+	_, lineHeight, _, err := createContent(gp.curr.Font_ISubset, text, gp.curr.Font_Size, nil)
+
+	for i, v := range []rune(text) {
+		lineWidth, _ := gp.MeasureTextWidth(string(line))
+		runeWidth, _ := gp.MeasureTextWidth(string(v))
+
+		if lineWidth+runeWidth > rectangle.W {
+			gp.Cell(&Rect{W: rectangle.W, H: lineHeight}, string(line))
+			gp.Br(lineHeight)
+			line = nil
+		}
+
+		line = append(line, v)
+
+		if i == length-1 {
+			gp.Cell(&Rect{W: rectangle.W, H: lineHeight}, string(line))
+			gp.Br(lineHeight)
+		}
+	}
+}
+
 //AddLink
 func (gp *GoPdf) AddExternalLink(url string, x, y, w, h float64) {
 	page := gp.pdfObjs[gp.curr.IndexOfPageObj].(*PageObj)


### PR DESCRIPTION
There were several requests for text wrapping, so I created a Cell method that supports multiple lines.

example

```
pdf.MultiCell(&gopdf.Rect{W: 80, H: 50}, "Hello gopdf! Add multiple lines Cell method with auto text wrapping")
```
