### PR TITLE
Fix boundary error in TTF handling

### DIFF
--- a/subset_font_obj.go
+++ b/subset_font_obj.go
@@ -166,7 +166,7 @@ func (s *SubsetFontObj) charCodeToGlyphIndexFormat12(r rune) (uint, error) {
 	value := uint(r)
 	gTbs := s.ttfp.GroupingTables()
 	for _, gTb := range gTbs {
-		if value >= gTb.StartCharCode && value < gTb.EndCharCode {
+		if value >= gTb.StartCharCode && value <= gTb.EndCharCode {
 			gIndex := (value - gTb.StartCharCode) + gTb.GlyphID
 			return gIndex, nil
 		}


### PR DESCRIPTION
I noticed certain characters were missing when using a custom font and tracked it down to the test for the EndCharCode in the GroupingTables not including the character. This caused a 'not found glyph' error.

Example showing missing characters (note variations of 'Z'):
<img width="785" alt="Screen Shot 2019-09-26 at 3 17 55 PM" src="https://user-images.githubusercontent.com/304910/65725952-17fe9f80-e071-11e9-890d-aae2f865fb1f.png">

Example showing characters included after fix:
<img width="785" alt="Screen Shot 2019-09-26 at 3 17 14 PM" src="https://user-images.githubusercontent.com/304910/65725964-1e8d1700-e071-11e9-94e4-014f89300a85.png">