### PR TITLE
Add basic support for PDF outlines

### DIFF
--- a/catalog_obj.go
+++ b/catalog_obj.go
@@ -7,9 +7,11 @@ import (
 
 //CatalogObj : catalog dictionary
 type CatalogObj struct { //impl IObj
+	outlinesObjID int
 }
 
 func (c *CatalogObj) init(funcGetRoot func() *GoPdf) {
+        c.outlinesObjID = -1
 
 }
 
@@ -21,6 +23,14 @@ func (c *CatalogObj) write(w io.Writer, objID int) error {
 	io.WriteString(w, "<<\n")
 	fmt.Fprintf(w, "  /Type /%s\n", c.getType())
 	io.WriteString(w, "  /Pages 2 0 R\n")
+	if c.outlinesObjID >= 0 {
+		io.WriteString(w, "  /PageMode /UseOutlines\n")
+		fmt.Fprintf(w, "  /Outlines %d 0 R\n", c.outlinesObjID)
+	}
 	io.WriteString(w, ">>\n")
 	return nil
+}
+
+func (c *CatalogObj) SetIndexObjOutlines(index int) {
+	c.outlinesObjID = index + 1
 }

--- a/gopdf.go
+++ b/gopdf.go
@@ -338,9 +338,8 @@ func (gp *GoPdf) AddPageWithOption(opt PageOption) {
 }
 
 func (gp *GoPdf) AddOutline(title string) {
-        gp.outlines.AddOutline(gp.curr.IndexOfPageObj, title)
+        gp.outlines.AddOutline(gp.curr.IndexOfPageObj + 1, title)
 }
-
 
 //Start : init gopdf
 func (gp *GoPdf) Start(config Config) {

--- a/outlines_obj.go
+++ b/outlines_obj.go
@@ -1,0 +1,89 @@
+package gopdf
+
+import (
+	"fmt"
+	"io"
+)
+
+//OutlinesObj : outlines dictionary
+type OutlinesObj struct { //impl IObj
+	getRoot func() *GoPdf
+
+	index   int
+	first   int
+	last    int
+	count   int
+	lastObj *OutlineObj
+}
+
+func (o *OutlinesObj) init(funcGetRoot func() *GoPdf) {
+	o.getRoot = funcGetRoot
+	o.first = -1
+	o.last = -1
+}
+
+func (o *OutlinesObj) getType() string {
+	return "Outlines"
+}
+
+func (o *OutlinesObj) write(w io.Writer, objID int) error {
+	io.WriteString(w, "<<\n")
+	fmt.Fprintf(w, "  /Type /%s\n", o.getType())
+	fmt.Fprintf(w, "  /Count %d\n", o.count)
+	fmt.Fprintf(w, "  /First %d 0 R\n", o.first)
+	fmt.Fprintf(w, "  /Last %d 0 R\n", o.last)
+	io.WriteString(w, ">>\n")
+	return nil
+}
+
+func (o *OutlinesObj) SetIndexObjOutlines(index int) {
+	o.index = index
+}
+
+func (o *OutlinesObj) AddOutline(dest int, title string) {
+	oo := &OutlineObj{title: title, dest: dest, parent: o.index, prev: o.last, next: -1}
+	o.last = o.getRoot().addObj(oo) + 1
+	if o.first <= 0 {
+		o.first = o.last
+	}
+	if o.lastObj != nil {
+		o.lastObj.next = o.last
+	}
+	o.lastObj = oo
+	o.count++
+}
+
+func (o *OutlinesObj) Count() int {
+	return o.count
+}
+
+type OutlineObj struct { //impl IObj
+	title string
+
+	dest   int
+	parent int
+	prev   int
+	next   int
+}
+
+func (o *OutlineObj) init(funcGetRoot func() *GoPdf) {
+}
+
+func (o *OutlineObj) getType() string {
+	return "Outline"
+}
+
+func (o *OutlineObj) write(w io.Writer, objID int) error {
+	io.WriteString(w, "<<\n")
+	fmt.Fprintf(w, "  /Parent %d 0 R\n", o.parent + 1)
+	if o.prev >= 0 {
+		fmt.Fprintf(w, "  /Prev %d 0 R\n", o.prev)
+	}
+	if o.next >= 0 {
+		fmt.Fprintf(w, "  /Next %d 0 R\n", o.next)
+	}
+	fmt.Fprintf(w, "  /Dest [ %d 0 R /XYZ null null null ]\n", o.dest)
+	fmt.Fprintf(w, "  /Title <FEFF%s>\n", encodeUtf8(o.title))
+	io.WriteString(w, ">>\n")
+	return nil
+}


### PR DESCRIPTION
See https://github.com/signintech/gopdf/issues/47

Note that this add very basic support for outlines. I have added a method AddOutline that adds a bookmark with the specified title to the current page (the very first type of "destination" described at 12.3.2.2 / page 366 in https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/PDF32000_2008.pdf)

`
[ page /XYZ left top zoom ]
`

constrained to left=null top=null and zoom=null.



