### PR TITLE
[Feature] Add number of pages retrieval

### DIFF
--- a/gopdf.go
+++ b/gopdf.go
@@ -38,6 +38,9 @@ type GoPdf struct {
 	//index ของ obj pages
 	indexOfPagesObj int
 
+	//number of pages
+	numOfPagesObj int
+
 	//index ของ obj page อันแรก
 	indexOfFirstPageObj int
 
@@ -374,6 +377,8 @@ func (gp *GoPdf) AddPageWithOption(opt PageOption) {
 		gp.indexOfFirstPageObj = index
 	}
 	gp.curr.IndexOfPageObj = index
+
+	gp.numOfPagesObj++
 
 	//reset
 	gp.indexOfContent = -1
@@ -766,6 +771,11 @@ func (gp *GoPdf) UseImportedTemplate(tplid int, x float64, y float64, w float64,
 // GetNextObjectID gets the next object ID so that gofpdi knows where to start the object IDs.
 func (gp *GoPdf) GetNextObjectID() int {
 	return len(gp.pdfObjs) + 1
+}
+
+// GetNumberOfPages gets the number of pages from the PDF.
+func (gp *GoPdf) GetNumberOfPages() int {
+	return gp.numOfPagesObj
 }
 
 // ImportObjects imports objects from gofpdi into current document.

--- a/gopdf_test.go
+++ b/gopdf_test.go
@@ -152,7 +152,6 @@ func TestRetrievingNumberOfPdfPage(t *testing.T) {
 		return
 	}
 
-	log.Printf("pages count: %d", pdf.GetNumberOfPages())
 	if pdf.GetNumberOfPages() != 1 {
 		t.Error(err)
 		return
@@ -168,7 +167,6 @@ func TestRetrievingNumberOfPdfPage(t *testing.T) {
 	pdf.SetY(200)
 	pdf.Cell(nil, "gopher and gopher again")
 
-	log.Printf("pages count: %d", pdf.GetNumberOfPages())
 	if pdf.GetNumberOfPages() != 2 {
 		t.Error(err)
 		return

--- a/gopdf_test.go
+++ b/gopdf_test.go
@@ -113,6 +113,70 @@ func TestPdfWithImageHolder(t *testing.T) {
 	pdf.WritePdf("./test/out/image_test.pdf")
 }
 
+func TestRetrievingNumberOfPdfPage(t *testing.T) {
+	pdf := GoPdf{}
+	pdf.Start(Config{PageSize: Rect{W: 595.28, H: 841.89}}) //595.28, 841.89 = A4
+	if pdf.GetNumberOfPages() != 0 {
+		t.Error("Invalid starting number of pages, should be 0")
+		return
+	}
+
+	pdf.AddPage()
+	err := pdf.AddTTFFont("loma", "./test/res/times.ttf")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = pdf.SetFont("loma", "", 14)
+	if err != nil {
+		log.Print(err.Error())
+		return
+	}
+
+	bytesOfImg, err := ioutil.ReadFile("./test/res/gopher01.jpg")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	imgH, err := ImageHolderByBytes(bytesOfImg)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = pdf.ImageByHolder(imgH, 20.0, 20, nil)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	log.Printf("pages count: %d", pdf.GetNumberOfPages())
+	if pdf.GetNumberOfPages() != 1 {
+		t.Error(err)
+		return
+	}
+
+	pdf.SetX(250)
+	pdf.SetY(200)
+	pdf.Cell(nil, "gopher and gopher")
+
+	pdf.AddPage()
+
+	pdf.SetX(250)
+	pdf.SetY(200)
+	pdf.Cell(nil, "gopher and gopher again")
+
+	log.Printf("pages count: %d", pdf.GetNumberOfPages())
+	if pdf.GetNumberOfPages() != 2 {
+		t.Error(err)
+		return
+	}
+
+	pdf.WritePdf("./test/out/number_of_pages_test.pdf")
+}
+
 /*
 func TestBuffer(t *testing.T) {
 	b := bytes.NewReader([]byte("ssssssss"))


### PR DESCRIPTION
## Description
Adding a method to retrieve the number of pages already created at the PDF object, including constructing the number of pages object to be calculated

## Motivation and Context
When we creating pages with the PDF, there're times that we need information for the number of pages already created at the PDF, either for some calculations or something else. This pull-request is intended to fulfill that.

## How Has This Been Tested?
I've run the test successfully at local with the result: `ok  	github.com/signintech/gopdf	0.405s`

## Approach
Originally I intended to use `indexOfPagesObj` attribute, but it cannot be used (it will always return 1).  
Thus, I'm resorting to an additional attribute to be used as the number of pages' definition that will be increased when `AddPage` or `AddPageWithOption` executed.