### PR TITLE
Updated font size from int to float64

### DIFF
--- a/content_obj.go
+++ b/content_obj.go
@@ -344,8 +344,14 @@ func (c *ContentObj) appendRotateReset() {
 	c.listCache.append(&cache)
 }
 
-//ContentObjCalTextHeight calculates height of text.
+//ContentObjCalTextHeight : calculates height of text.
 func ContentObjCalTextHeight(fontsize int) float64 {
+	return ContentObjCalTextHeightPrecise(float64(fontsize))
+}
+
+//ContentObjCalTextHeightPrecise : like ContentObjCalTextHeight,
+// but fontsize float64
+func ContentObjCalTextHeightPrecise(fontsize float64) float64 {
 	return (float64(fontsize) * 0.7)
 }
 

--- a/current.go
+++ b/current.go
@@ -11,7 +11,7 @@ type Current struct {
 	CountOfFont    int
 	CountOfL       int
 
-	FontSize      int
+	FontSize      float64
 	FontStyle     int // Regular|Bold|Italic|Underline
 	FontFontCount int
 	FontType      int // CURRENT_FONT_TYPE_IFONT or  CURRENT_FONT_TYPE_SUBSET

--- a/fontsizefloat64_test.go
+++ b/fontsizefloat64_test.go
@@ -1,0 +1,110 @@
+package gopdf
+
+import (
+	"testing"
+)
+
+func TestContentObjCalTextHeight(t *testing.T) {
+	intfontsize := 7
+	have := ContentObjCalTextHeight(intfontsize)
+	want := float64(intfontsize) * 0.7
+	if have != want {
+		t.Errorf("ContentObjCalTextHeight(%d) = %f; want %f\n", intfontsize, have, want)
+	}
+
+	floatfontsize := 7.2
+	have = ContentObjCalTextHeightPrecise(floatfontsize)
+	want = float64(floatfontsize) * 0.7
+	if have != want {
+		t.Errorf("ContentObjCalTextHeight(%d) = %f; want %f\n", intfontsize, have, want)
+	}
+
+}
+
+func TestSetFontCheckGetX(t *testing.T) {
+	prefix := "Afont"
+	font := "test/res/LiberationSerif-Regular.ttf"
+	pdf := GoPdf{}
+	pdf.Start(Config{Unit: UnitPT, PageSize: Rect{W: 595.28, H: 841.89}})
+	pdf.AddPage()
+	if err := pdf.AddTTFFontWithOption(prefix, font, TtfOption{UseKerning: true}); err != nil {
+		t.Error(err)
+	}
+
+	// Baseline: SetFont(int) + AddText
+	if err := pdf.SetFont(prefix, "", int(50)); err != nil {
+		t.Error(err)
+	}
+
+	pdf.SetX(30.0)
+	pdf.SetY(30.0)
+	pdf.Text(prefix)
+	wantx, wanty := pdf.GetX(), pdf.GetY()
+
+	// ensure that GetX, GetY work as expected
+	pdf.SetX(30.0)
+	pdf.SetY(30.0)
+	pdf.Text(prefix + prefix)
+	havex, havey := pdf.GetX(), pdf.GetY()
+	if havex <= wantx || havey != wanty {
+		t.Errorf("wanted (x,y) => (x', y') with x<x' and y==y', got (%f, %f) => (%f, %f)\n", wantx, wanty, havex, havey)
+	}
+}
+
+func moveAndAdd(pdf *GoPdf, prefix string) (float64, float64) {
+	pdf.SetX(30.0)
+	pdf.SetY(30.0)
+	pdf.Text(prefix)
+	return pdf.GetX(), pdf.GetY()
+}
+func setup(t *testing.T) (string, *GoPdf, float64, float64) {
+	prefix := "Afont"
+	font := "test/res/LiberationSerif-Regular.ttf"
+	pdf := GoPdf{}
+	pdf.Start(Config{Unit: UnitPT, PageSize: Rect{W: 595.28, H: 841.89}})
+	pdf.AddPage()
+	if err := pdf.AddTTFFontWithOption(prefix, font, TtfOption{UseKerning: true}); err != nil {
+		t.Error(err)
+	}
+
+	// Baseline: SetFont(int) + AddText
+	if err := pdf.SetFont(prefix, "", int(50)); err != nil {
+		t.Error(err)
+	}
+	hx, hy := moveAndAdd(&pdf, prefix)
+	return prefix, &pdf, hx, hy
+}
+func TestSetFontWithFloat(t *testing.T) {
+	prefix, pdf, wantx, wanty := setup(t)
+	// try it with fontsize = float64(50)
+	if err := pdf.SetFont(prefix, "", float64(50)); err != nil {
+		t.Error(err)
+	}
+	havex, havey := moveAndAdd(pdf, prefix)
+	if (havex != wantx) || (havey != wanty) {
+		t.Errorf("SetFont(float64) + '%s' => \nhave = %f, %f;\nwant = %f,%f\n",
+			prefix, havex, havey, wantx, wanty)
+	}
+}
+
+func TestSetFontWithUint(t *testing.T) {
+	prefix, pdf, wantx, wanty := setup(t)
+	// try it with fontsize = uint8(50)
+	if err := pdf.SetFont(prefix, "", uint8(50)); err != nil {
+		t.Error(err)
+	}
+	havex, havey := moveAndAdd(pdf, prefix)
+	if (havex != wantx) || (havey != wanty) {
+		t.Errorf("SetFont(uint8) + AddText => %f, %f; want = %f,%f\n",
+			havex, havey, wantx, wanty)
+	}
+}
+func TestSetFontWithString(t *testing.T) {
+	prefix, pdf, _, _ := setup(t)
+	// Try with a string
+	err := pdf.SetFont(prefix, "", string("50"))
+	if err == nil {
+		t.Errorf("SetFont(string) + AddText: Should have gotten an error!\n")
+	}
+
+}

--- a/gopdf.go
+++ b/gopdf.go
@@ -686,10 +686,46 @@ func (gp *GoPdf) Start(config Config) {
 
 }
 
+// convertNumericToFloat64 : accept numeric types, return float64-value
+func convertNumericToFloat64(size interface{}) (fontSize float64, err error) {
+	switch size := size.(type) {
+	case float32:
+		return float64(size), nil
+	case float64:
+		return float64(size), nil
+	case int:
+		return float64(size), nil
+	case int16:
+		return float64(size), nil
+	case int32:
+		return float64(size), nil
+	case int64:
+		return float64(size), nil
+	case int8:
+		return float64(size), nil
+	case uint:
+		return float64(size), nil
+	case uint16:
+		return float64(size), nil
+	case uint32:
+		return float64(size), nil
+	case uint64:
+		return float64(size), nil
+	case uint8:
+		return float64(size), nil
+	default:
+		return 0.0, errors.Errorf("fontSize must be of type (u)int* or float*, not %T", size)
+	}
+}
+
 // SetFontWithStyle : set font style support Regular or Underline
 // for Bold|Italic should be loaded apropriate fonts with same styles defined
-func (gp *GoPdf) SetFontWithStyle(family string, style int, size int) error {
-
+// size MUST be uint*, int* or float64*
+func (gp *GoPdf) SetFontWithStyle(family string, style int, size interface{}) error {
+	fontSize, err := convertNumericToFloat64(size)
+	if err != nil {
+		return err
+	}
 	found := false
 	i := 0
 	max := len(gp.pdfObjs)
@@ -699,7 +735,7 @@ func (gp *GoPdf) SetFontWithStyle(family string, style int, size int) error {
 			sub, ok := obj.(*SubsetFontObj)
 			if ok {
 				if sub.GetFamily() == family && sub.GetTtfFontOption().Style == style&^Underline {
-					gp.curr.FontSize = size
+					gp.curr.FontSize = fontSize
 					gp.curr.FontStyle = style
 					gp.curr.FontFontCount = sub.CountOfFont
 					gp.curr.FontISubset = sub
@@ -720,8 +756,16 @@ func (gp *GoPdf) SetFontWithStyle(family string, style int, size int) error {
 
 //SetFont : set font style support "" or "U"
 // for "B" and "I" should be loaded apropriate fonts with same styles defined
-func (gp *GoPdf) SetFont(family string, style string, size int) error {
+// size MUST be uint*, int* or float64*
+func (gp *GoPdf) SetFont(family string, style string, size interface{}) error {
 	return gp.SetFontWithStyle(family, getConvertedStyle(style), size)
+}
+
+//SetFontSize : set the font size (and only the font size) of the currently
+// active font
+func (gp *GoPdf) SetFontSize(fontSize float64) error {
+	gp.curr.FontSize = fontSize
+	return nil
 }
 
 //WritePdf : wirte pdf file

--- a/strhelper.go
+++ b/strhelper.go
@@ -7,6 +7,12 @@ import (
 
 //StrHelperGetStringWidth get string width
 func StrHelperGetStringWidth(str string, fontSize int, ifont IFont) float64 {
+	return StrHelperGetStringWidthPrecise(str, float64(fontSize), ifont)
+}
+
+//StrHelperGetStringWidthPrecise get string width with real number fontSize
+func StrHelperGetStringWidthPrecise(str string, fontSize float64, ifont IFont) float64 {
+
 	w := 0
 	bs := []byte(str)
 	i := 0


### PR DESCRIPTION
(as has been suggested/asked for in https://github.com/signintech/gopdf/issues/86)

There are four exported `func`s that take `fontsize int` as an argument, blindly changing this to `fontsize float64` would cause a lot of breakage.

To avoid any problems, functionality of these
> content_obj.go:
    `func ContentObjCalTextHeight(fontsize int) float64`
> strhelper.go:
    `func StrHelperGetStringWidth(str string, fontSize int, ifont IFont) float64`

has been moved into new functions `StrHelperGetStringWidthPrecise`, `ContentObjCalTextHeightPrecise` that accept `fontsize float64`, the old functions then call the new func with float64(fontSize).

That could also be done for these
> gopdf.go:
    `func (gp *GoPdf) SetFontWithStyle(family string, style int, size int) error`
    `func (gp *GoPdf) SetFont(family string, style string, size int) error`

But since they return `error`, the `fontsize int` can also be changed to
`fontsize interface{}`, so that the func accepts any type as "fontsize".
The type can then be checked at runtime, if it's a numeric type (`uint*`,
`int*`, `float*`), the function can proceed with `float64(fontsize)`,
otherwise an error can be returned to the caller.

In case the functionality makes sense in other places, helper
`func convertNumericToFloat64(size interface{}) (float64, error)`
has been added.

Oh, and a couple of tests, to ensure that `SetFont(..., size interface{})` works as expected. 