### PR TITLE
Add random binary characters in file header generation for ISO 32000-1 compliance

### DIFF
--- a/gopdf.go
+++ b/gopdf.go
@@ -829,8 +829,7 @@ func (gp *GoPdf) compilePdf(w io.Writer) error {
 	}
 	max := len(gp.pdfObjs)
 	writer := newCountingWriter(w)
-	//io.WriteString(w, "%PDF-1.7\n\n")
-	fmt.Fprint(writer, "%PDF-1.7\n\n")
+	fmt.Fprint(writer, "%PDF-1.7\n%����\n\n")
 	linelens := make([]int, max)
 	i := 0
 


### PR DESCRIPTION
Fixes #207 

This PR adds some random binary characters in the file header generation for ISO 32000-1 compliance as mentioned in https://github.com/signintech/gopdf/issues/207#issue-1086421272.