### PR TITLE
Introduce SplitTextWithOption to allow configurable text splitting.

### DIFF
--- a/break_option.go
+++ b/break_option.go
@@ -1,0 +1,39 @@
+package gopdf
+
+// BreakMode type for text break modes.
+type BreakMode int
+
+const (
+	// BreakModeStrict causes the text-line to break immediately in case the current character would not fit into
+	// the processed text-line. The separator (if provided) will be attached accordingly as a line suffix
+	// to stay within the defined width.
+	BreakModeStrict BreakMode = iota
+
+	// BreakModeIndicatorSensitive will try to break the current line based on the last index of a provided
+	// BreakIndicator. If no indicator sensitive break can be performed a strict break will be performed,
+	// potentially working with the given separator as a suffix.
+	BreakModeIndicatorSensitive
+)
+
+var (
+	// DefaultBreakOption will cause the text to break mid-word without any separator suffixes.
+	DefaultBreakOption = BreakOption{
+		Mode:           BreakModeStrict,
+		BreakIndicator: 0,
+		Separator:      "",
+	}
+)
+
+// BreakOption allows to configure the behavior of splitting or breaking larger texts via SplitTextWithOption.
+type BreakOption struct {
+	// Mode defines the mode which should be used
+	Mode BreakMode
+	// BreakIndicator is taken into account when using indicator sensitive mode to avoid mid-word line breaks
+	BreakIndicator rune
+	// Separator will act as a suffix for mid-word breaks when using strict mode
+	Separator string
+}
+
+func (bo BreakOption) HasSeparator() bool {
+	return bo.Separator != ""
+}

--- a/gopdf_test.go
+++ b/gopdf_test.go
@@ -620,7 +620,7 @@ func TestClearValue(t *testing.T) {
 	}
 }
 
-func TestSplitTextWithWordWrap(t *testing.T) {
+func TestSplitTextWithOptions(t *testing.T) {
 	err := initTesting()
 	if err != nil {
 		t.Error(err)
@@ -629,31 +629,65 @@ func TestSplitTextWithWordWrap(t *testing.T) {
 
 	pdf := setupDefaultA4PDF(t)
 
-	var splitTextTests = []struct{
+	var splitTextTests = []struct {
 		name string
-		in string
-		exp []string
+		in   string
+		opts *BreakOption
+		exp  []string
 	}{
+		{
+			"strict breaks no separator",
+			"Lorem ipsum dolor sit amet, consetetur",
+			&DefaultBreakOption,
+			[]string{"Lorem ipsum dol", "or sit amet, conse", "tetur"},
+		},
+		{
+			"no options given",
+			"Lorem ipsum dolor sit amet, consetetur",
+			nil,
+			[]string{"Lorem ipsum dol", "or sit amet, conse", "tetur"},
+		},
+		{
+			"strict breaks with separator",
+			"Lorem ipsum dolor sit amet, consetetur",
+			&BreakOption{
+				Separator: "-",
+				Mode:      BreakModeStrict,
+			},
+			[]string{"Lorem ipsum d-", "olor sit amet, c-", "onsetetur"},
+		},
 		{
 			"text with possible word-wrap",
 			"Lorem ipsum dolor sit amet, consetetur",
+			&BreakOption{
+				BreakIndicator: ' ',
+				Mode:           BreakModeIndicatorSensitive,
+			},
 			[]string{"Lorem ipsum", "dolor sit amet,", "consetetur"},
 		},
 		{
 			"text without possible word-wrap",
 			"Loremipsumdolorsitamet,consetetur",
+			&BreakOption{
+				BreakIndicator: ' ',
+				Mode:           BreakModeIndicatorSensitive,
+			},
 			[]string{"Loremipsumdolo", "rsitamet,consetet", "ur"},
 		},
 		{
 			"text with only empty spaces",
 			"                                                ",
+			&BreakOption{
+				BreakIndicator: ' ',
+				Mode:           BreakModeIndicatorSensitive,
+			},
 			[]string{"                           ", "                    "},
 		},
 	}
 
 	for _, tt := range splitTextTests {
 		t.Run(tt.name, func(t *testing.T) {
-			lines, err := pdf.SplitTextWithWordWrap(tt.in, 100)
+			lines, err := pdf.SplitTextWithOption(tt.in, 100, tt.opts)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
To have a higher level of flexibiliity and reduce repetitive code SplitTextWithOption is now the underlying text splitting implementation for SplitText and SplitTextWithWordWrap. Splitting can now be performed individually based on language or font specifics. Two break modes are now available to process texts either with a strict break (allowing mid-word breaks) or with an identifier-sensitive mode (avoiding mid-word breaks). See the code documentation of BreakOption for more info.

Hey @oneplus1000 & @renjunok, I refactored the code in order to be as flexible as possible for different language "restrictions" and text splitting. Since the previous PR (https://github.com/signintech/gopdf/pull/216) got merged a bit too quickly I couldn't update it before it went to master.

Feel free to discuss the approach within this contribution :-)

Cheers