### PR TITLE
Add possibility to use CMYK color mode for fill and stroke

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,17 @@ if err != nil {
 }
 ```
 
+### Draw rectangle with round corner in CMYK color mode
+```go
+pdf.SetStrokeColorCMYK(88, 49, 0, 0)
+pdf.SetLineWidth(2)
+pdf.SetFillColorCMYK(0, 5, 89, 0)
+err := pdf.Rectangle(196.6, 336.8, 398.3, 379.3, "DF", 3, 10)
+if err != nil {
+	return err
+}
+```
+
 ### Rotation text or image
 ```go
 pdf.SetXY(100, 100)

--- a/cache_content_color_cmyk.go
+++ b/cache_content_color_cmyk.go
@@ -1,0 +1,19 @@
+package gopdf
+
+import (
+	"fmt"
+	"io"
+)
+
+const cmykTypeStroke = "K"
+const cmykTypeFill = "k"
+
+type cacheContentCMYK struct {
+	colorType  string
+	c, m, y, k uint8
+}
+
+func (c *cacheContentCMYK) write(w io.Writer, protection *PDFProtection) error {
+	fmt.Fprintf(w, "%.2f %.2f %.2f %.2f %s\n", float64(c.c)/100, float64(c.m)/100, float64(c.y)/100, float64(c.k)/100, c.colorType)
+	return nil
+}

--- a/content_obj.go
+++ b/content_obj.go
@@ -298,6 +298,28 @@ func (c *ContentObj) AppendStreamSetColorFill(r uint8, g uint8, b uint8) {
 	c.listCache.append(&cache)
 }
 
+//AppendStreamSetColorStrokeCMYK  set the color stroke in CMYK color mode
+func (c *ContentObj) AppendStreamSetColorStrokeCMYK(cy, m, y, k uint8) {
+	var cache cacheContentCMYK
+	cache.colorType = cmykTypeStroke
+	cache.c = cy
+	cache.m = m
+	cache.y = y
+	cache.k = k
+	c.listCache.append(&cache)
+}
+
+//AppendStreamSetColorFillCMYK  set the color fill in CMYK color mode
+func (c *ContentObj) AppendStreamSetColorFillCMYK(cy, m, y, k uint8) {
+	var cache cacheContentCMYK
+	cache.colorType = cmykTypeFill
+	cache.c = cy
+	cache.m = m
+	cache.y = y
+	cache.k = k
+	c.listCache.append(&cache)
+}
+
 func (c *ContentObj) GetCacheContentImage(index int, opts ImageOptions) *cacheContentImage {
 	h := c.getRoot().curr.pageSize.H
 

--- a/gopdf.go
+++ b/gopdf.go
@@ -1533,6 +1533,16 @@ func (gp *GoPdf) SetFillColor(r uint8, g uint8, b uint8) {
 	gp.getContent().AppendStreamSetColorFill(r, g, b)
 }
 
+//SetStrokeColorCMYK set the color for the stroke in CMYK color mode
+func (gp *GoPdf) SetStrokeColorCMYK(c, m, y, k uint8) {
+	gp.getContent().AppendStreamSetColorStrokeCMYK(c, m, y, k)
+}
+
+//SetFillColorCMYK set the color for the fill in CMYK color mode
+func (gp *GoPdf) SetFillColorCMYK(c, m, y, k uint8) {
+	gp.getContent().AppendStreamSetColorFillCMYK(c, m, y, k)
+}
+
 //MeasureTextWidth : measure Width of text (use current font)
 func (gp *GoPdf) MeasureTextWidth(text string) (float64, error) {
 


### PR DESCRIPTION
New methods were added to keep the library backward compatible with previous versions.
