### PR TITLE
Add CMYK color model support for text

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ func main() {
 }
 
 ```
+
+### Set text color using RGB color model
+
+```go
+pdf.SetTextColor(156, 197, 140)
+pdf.Cell(nil, "您好")
+```
+
+### Set text color using CMYK color model
+
+```go
+pdf.SetTextColorCMYK(0, 6, 14, 0)
+pdf.Cell
+```
   
 ### Image
   
@@ -165,7 +179,7 @@ if err != nil {
 }
 ```
 
-### Draw rectangle with round corner in CMYK color mode
+### Draw rectangle with round corner using CMYK color model
 ```go
 pdf.SetStrokeColorCMYK(88, 49, 0, 0)
 pdf.SetLineWidth(2)

--- a/cache_contact_color_rgb.go
+++ b/cache_contact_color_rgb.go
@@ -5,16 +5,16 @@ import (
 	"io"
 )
 
-const colorTypeStroke = "RG"
+const colorTypeStrokeRGB = "RG"
 
-const colorTypeFill = "rg"
+const colorTypeFillRGB = "rg"
 
-type cacheContentColor struct {
+type cacheContentColorRGB struct {
 	colorType string
 	r, g, b   uint8
 }
 
-func (c *cacheContentColor) write(w io.Writer, protection *PDFProtection) error {
+func (c *cacheContentColorRGB) write(w io.Writer, protection *PDFProtection) error {
 	fmt.Fprintf(w, "%.3f %.3f %.3f %s\n", float64(c.r)/255, float64(c.g)/255, float64(c.b)/255, c.colorType)
 	return nil
 }

--- a/cache_content_color_cmyk.go
+++ b/cache_content_color_cmyk.go
@@ -5,15 +5,16 @@ import (
 	"io"
 )
 
-const cmykTypeStroke = "K"
-const cmykTypeFill = "k"
+const colorTypeStrokeCMYK = "K"
 
-type cacheContentCMYK struct {
+const colorTypeFillCMYK = "k"
+
+type cacheContentColorCMYK struct {
 	colorType  string
 	c, m, y, k uint8
 }
 
-func (c *cacheContentCMYK) write(w io.Writer, protection *PDFProtection) error {
+func (c *cacheContentColorCMYK) write(w io.Writer, protection *PDFProtection) error {
 	fmt.Fprintf(w, "%.2f %.2f %.2f %.2f %s\n", float64(c.c)/100, float64(c.m)/100, float64(c.y)/100, float64(c.k)/100, c.colorType)
 	return nil
 }

--- a/cache_content_text_color_cmyk.go
+++ b/cache_content_text_color_cmyk.go
@@ -15,7 +15,10 @@ func (c cacheContentTextColorCMYK) write(w io.Writer, protection *PDFProtection)
 }
 
 func (c cacheContentTextColorCMYK) equal(obj ICacheColorText) bool {
-	cmyk := obj.(cacheContentTextColorCMYK)
+	cmyk, ok := obj.(cacheContentTextColorCMYK)
+	if !ok {
+		return false
+	}
 
 	return c.c == cmyk.c && c.m == cmyk.m && c.y == cmyk.y && c.k == cmyk.k
 }

--- a/cache_content_text_color_cmyk.go
+++ b/cache_content_text_color_cmyk.go
@@ -1,0 +1,21 @@
+package gopdf
+
+import (
+	"fmt"
+	"io"
+)
+
+type cacheContentTextColorCMYK struct {
+	c, m, y, k uint8
+}
+
+func (c cacheContentTextColorCMYK) write(w io.Writer, protection *PDFProtection) error {
+	fmt.Fprintf(w, "%.2f %.2f %.2f %.2f %s\n", float64(c.c)/100, float64(c.m)/100, float64(c.y)/100, float64(c.k)/100, colorTypeFillCMYK)
+	return nil
+}
+
+func (c cacheContentTextColorCMYK) equal(obj ICacheColorText) bool {
+	cmyk := obj.(cacheContentTextColorCMYK)
+
+	return c.c == cmyk.c && c.m == cmyk.m && c.y == cmyk.y && c.k == cmyk.k
+}

--- a/cache_content_text_color_rgb.go
+++ b/cache_content_text_color_rgb.go
@@ -15,7 +15,10 @@ func (c cacheContentTextColorRGB) write(w io.Writer, protection *PDFProtection) 
 }
 
 func (c cacheContentTextColorRGB) equal(obj ICacheColorText) bool {
-	rgb := obj.(cacheContentTextColorRGB)
+	rgb, ok := obj.(cacheContentTextColorRGB)
+	if !ok {
+		return false
+	}
 
 	return c.r == rgb.r && c.g == rgb.g && c.b == rgb.b
 }

--- a/cache_content_text_color_rgb.go
+++ b/cache_content_text_color_rgb.go
@@ -1,0 +1,21 @@
+package gopdf
+
+import (
+	"fmt"
+	"io"
+)
+
+type cacheContentTextColorRGB struct {
+	r, g, b uint8
+}
+
+func (c cacheContentTextColorRGB) write(w io.Writer, protection *PDFProtection) error {
+	fmt.Fprintf(w, "%.3f %.3f %.3f %s\n", float64(c.r)/255, float64(c.g)/255, float64(c.b)/255, colorTypeFillRGB)
+	return nil
+}
+
+func (c cacheContentTextColorRGB) equal(obj ICacheColorText) bool {
+	rgb := obj.(cacheContentTextColorRGB)
+
+	return c.r == rgb.r && c.g == rgb.g && c.b == rgb.b
+}

--- a/content_obj.go
+++ b/content_obj.go
@@ -280,8 +280,8 @@ func (c *ContentObj) AppendStreamSetGrayStroke(w float64) {
 
 //AppendStreamSetColorStroke  set the color stroke
 func (c *ContentObj) AppendStreamSetColorStroke(r uint8, g uint8, b uint8) {
-	var cache cacheContentColor
-	cache.colorType = colorTypeStroke
+	var cache cacheContentColorRGB
+	cache.colorType = colorTypeStrokeRGB
 	cache.r = r
 	cache.g = g
 	cache.b = b
@@ -290,8 +290,8 @@ func (c *ContentObj) AppendStreamSetColorStroke(r uint8, g uint8, b uint8) {
 
 //AppendStreamSetColorFill  set the color fill
 func (c *ContentObj) AppendStreamSetColorFill(r uint8, g uint8, b uint8) {
-	var cache cacheContentColor
-	cache.colorType = colorTypeFill
+	var cache cacheContentColorRGB
+	cache.colorType = colorTypeFillRGB
 	cache.r = r
 	cache.g = g
 	cache.b = b
@@ -300,8 +300,8 @@ func (c *ContentObj) AppendStreamSetColorFill(r uint8, g uint8, b uint8) {
 
 //AppendStreamSetColorStrokeCMYK  set the color stroke in CMYK color mode
 func (c *ContentObj) AppendStreamSetColorStrokeCMYK(cy, m, y, k uint8) {
-	var cache cacheContentCMYK
-	cache.colorType = cmykTypeStroke
+	var cache cacheContentColorCMYK
+	cache.colorType = colorTypeStrokeCMYK
 	cache.c = cy
 	cache.m = m
 	cache.y = y
@@ -311,8 +311,8 @@ func (c *ContentObj) AppendStreamSetColorStrokeCMYK(cy, m, y, k uint8) {
 
 //AppendStreamSetColorFillCMYK  set the color fill in CMYK color mode
 func (c *ContentObj) AppendStreamSetColorFillCMYK(cy, m, y, k uint8) {
-	var cache cacheContentCMYK
-	cache.colorType = cmykTypeFill
+	var cache cacheContentColorCMYK
+	cache.colorType = colorTypeFillCMYK
 	cache.c = cy
 	cache.m = m
 	cache.y = y

--- a/current.go
+++ b/current.go
@@ -30,7 +30,7 @@ type Current struct {
 	txtColorMode string //color, gray
 
 	//text color
-	txtColor Rgb
+	txtColor ICacheColorText
 
 	//text grayscale
 	grayFill float64
@@ -51,11 +51,11 @@ type Current struct {
 	transparencyMap TransparencyMap
 }
 
-func (c *Current) setTextColor(rgb Rgb) {
-	c.txtColor = rgb
+func (c *Current) setTextColor(color ICacheColorText) {
+	c.txtColor = color
 }
 
-func (c *Current) textColor() Rgb {
+func (c *Current) textColor() ICacheColorText {
 	return c.txtColor
 }
 
@@ -64,33 +64,4 @@ type ImageCache struct {
 	Path  string //ID or Path
 	Index int
 	Rect  *Rect
-}
-
-//Rgb  rgb color
-type Rgb struct {
-	r uint8
-	g uint8
-	b uint8
-}
-
-//SetR set red
-func (rgb *Rgb) SetR(r uint8) {
-	rgb.r = r
-}
-
-//SetG set green
-func (rgb *Rgb) SetG(g uint8) {
-	rgb.g = g
-}
-
-//SetB set blue
-func (rgb *Rgb) SetB(b uint8) {
-	rgb.b = b
-}
-
-func (rgb Rgb) equal(obj Rgb) bool {
-	if rgb.r == obj.r && rgb.g == obj.g && rgb.b == obj.b {
-		return true
-	}
-	return false
 }

--- a/gopdf.go
+++ b/gopdf.go
@@ -1515,12 +1515,23 @@ func (gp *GoPdf) KernOverride(family string, fn FuncKernOverride) error {
 //SetTextColor :  function sets the text color
 func (gp *GoPdf) SetTextColor(r uint8, g uint8, b uint8) {
 	gp.curr.txtColorMode = "color"
-	rgb := Rgb{
+	rgb := cacheContentTextColorRGB{
 		r: r,
 		g: g,
 		b: b,
 	}
 	gp.curr.setTextColor(rgb)
+}
+
+func (gp *GoPdf) SetTextColorCMYK(c, m, y, k uint8) {
+	gp.curr.txtColorMode = "color"
+	cmyk := cacheContentTextColorCMYK{
+		c: c,
+		m: m,
+		y: y,
+		k: k,
+	}
+	gp.curr.setTextColor(cmyk)
 }
 
 //SetStrokeColor set the color for the stroke

--- a/gopdf_test.go
+++ b/gopdf_test.go
@@ -694,7 +694,7 @@ func TestSplitTextWithOptions(t *testing.T) {
 	}
 }
 
-func TestTextColorRGB(t *testing.T) {
+func TestTextColor(t *testing.T) {
 	err := initTesting()
 	if err != nil {
 		t.Error(err)
@@ -717,51 +717,15 @@ func TestTextColorRGB(t *testing.T) {
 		return
 	}
 
-	pdf.SetTextColor(0, 255, 255)
-	err = pdf.Cell(nil, "I'm colored text using RGB color model")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	err = pdf.WritePdf("./test/out/colored_text_rgb.pdf")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-}
-
-func TestTextColorCMYK(t *testing.T) {
-	err := initTesting()
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	// create pdf.
-	pdf := GoPdf{}
-	pdf.Start(Config{PageSize: *PageSizeA4})
-	pdf.AddPage()
-	err = pdf.AddTTFFont("LiberationSerif", "./test/res/LiberationSerif-Regular.ttf")
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	err = pdf.SetFont("LiberationSerif", "", 14)
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	pdf.SetTextColor(255, 0, 2)
+	pdf.Br(20)
+	pdf.Cell(nil, "a")
 
 	pdf.SetTextColorCMYK(0, 6, 14, 0)
-	err = pdf.Cell(nil, "I'm colored text using CMYK color model")
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	pdf.Br(20)
+	pdf.Cell(nil, "b")
 
-	err = pdf.WritePdf("./test/out/colored_text_cmyk.pdf")
+	err = pdf.WritePdf("./test/out/colored_text.pdf")
 	if err != nil {
 		t.Error(err)
 		return

--- a/gopdf_test.go
+++ b/gopdf_test.go
@@ -694,6 +694,80 @@ func TestSplitTextWithOptions(t *testing.T) {
 	}
 }
 
+func TestTextColorRGB(t *testing.T) {
+	err := initTesting()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// create pdf.
+	pdf := GoPdf{}
+	pdf.Start(Config{PageSize: *PageSizeA4})
+	pdf.AddPage()
+	err = pdf.AddTTFFont("LiberationSerif", "./test/res/LiberationSerif-Regular.ttf")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = pdf.SetFont("LiberationSerif", "", 14)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	pdf.SetTextColor(0, 255, 255)
+	err = pdf.Cell(nil, "I'm colored text using RGB color model")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = pdf.WritePdf("./test/out/colored_text_rgb.pdf")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+}
+
+func TestTextColorCMYK(t *testing.T) {
+	err := initTesting()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// create pdf.
+	pdf := GoPdf{}
+	pdf.Start(Config{PageSize: *PageSizeA4})
+	pdf.AddPage()
+	err = pdf.AddTTFFont("LiberationSerif", "./test/res/LiberationSerif-Regular.ttf")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = pdf.SetFont("LiberationSerif", "", 14)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	pdf.SetTextColorCMYK(0, 6, 14, 0)
+	err = pdf.Cell(nil, "I'm colored text using CMYK color model")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = pdf.WritePdf("./test/out/colored_text_cmyk.pdf")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+}
+
 func initTesting() error {
 	err := os.MkdirAll("./test/out", 0777)
 	if err != nil {

--- a/i_cache_color_text.go
+++ b/i_cache_color_text.go
@@ -1,0 +1,6 @@
+package gopdf
+
+type ICacheColorText interface {
+	ICacheContent
+	equal(obj ICacheColorText) bool
+}


### PR DESCRIPTION
1. Added support of CMYK color model for text. In the future it can be easily extended to support more color models.
2. Adjusted naming to be more consistent