### PR TITLE
Fix MultiCell metohd

### DIFF
--- a/gopdf.go
+++ b/gopdf.go
@@ -1061,6 +1061,7 @@ func (gp *GoPdf) MultiCell(rectangle *Rect, text string) error {
 	if err != nil {
 		return err
 	}
+	gp.PointsToUnitsVar(&lineHeight)
 
 	for i, v := range []rune(text) {
 		if totalLineHeight+lineHeight > rectangle.H {


### PR DESCRIPTION
The MultiCell method doesn't respect unit that is set at initialization.
```
pdf := gopdf.GoPdf{}
pdf.Start(gopdf.Config{PageSize: *gopdf.PageSizeA4, Unit: gopdf.UnitCM})
```


So here is the fix.