### PR TITLE
change jpeg to png to support transparency values

### DIFF
--- a/gopdf.go
+++ b/gopdf.go
@@ -710,7 +710,7 @@ func (gp *GoPdf) ImageFrom(img image.Image, x float64, y float64, rect *Rect) er
 	r, w := io.Pipe()
 	go func() {
 		bw := bufio.NewWriter(w)
-		err := jpeg.Encode(bw, img, nil)
+		err := png.Encode(bw, img, nil)
 		bw.Flush()
 		if err != nil {
 			w.CloseWithError(err)


### PR DESCRIPTION
Solves the issue in #214 and fixes my own problem of not being able to load images with transparency from memory easily.