### PR TITLE
Fixing spacing between different text cache box

### DIFF
--- a/list_cache_content.go
+++ b/list_cache_content.go
@@ -43,17 +43,17 @@ func (l *listCacheContent) appendContentText(cache cacheContentText, text string
 	//start add text
 	cacheFont.text += text
 
-	//re-create contnet
+	//re-create content
 	textWidthPdfUnit, textHeightPdfUnit, err := cacheFont.createContent()
 	if err != nil {
 		return x, y, err
 	}
 
 	if cacheFont.cellOpt.Float == 0 || cacheFont.cellOpt.Float&Right == Right || cacheFont.contentType == ContentTypeText {
-		x += textWidthPdfUnit
+		x = cacheFont.x + textWidthPdfUnit
 	}
 	if cacheFont.cellOpt.Float&Bottom == Bottom {
-		y += textHeightPdfUnit
+		y = cacheFont.y + textHeightPdfUnit
 	}
 
 	return x, y, nil


### PR DESCRIPTION
This PR fixes an issue when changing font configuration in the middle of a text added to a PDF.

Before:
![DeepinScreenshot_select-area_20220905193640](https://user-images.githubusercontent.com/421550/188514648-56ef9fff-b200-4b4d-a37f-b0d944242e5a.png)

After:
![DeepinScreenshot_select-area_20220905234153](https://user-images.githubusercontent.com/421550/188514717-0ab55f96-0908-4b4e-937b-372c0118fc19.png)

Another example from https://github.com/signintech/gopdf/issues/149 :
Before:
![DeepinScreenshot_select-area_20220905234354](https://user-images.githubusercontent.com/421550/188514911-9cea223f-efcb-4808-bc89-ce8021d24bd8.png)
After:
![DeepinScreenshot_select-area_20220905234502](https://user-images.githubusercontent.com/421550/188514921-c56cffaf-9498-45f3-91ae-ade991beacf5.png)
