### PR TITLE
gofmt on go 1.19

### DIFF
--- a/buff.go
+++ b/buff.go
@@ -1,12 +1,12 @@
 package gopdf
 
-//Buff for pdf content
+// Buff for pdf content
 type Buff struct {
 	position int
 	datas    []byte
 }
 
-//Write : write []byte to buffer
+// Write : write []byte to buffer
 func (b *Buff) Write(p []byte) (int, error) {
 	for len(b.datas) < b.position+len(p) {
 		b.datas = append(b.datas, 0)
@@ -21,22 +21,22 @@ func (b *Buff) Write(p []byte) (int, error) {
 	return 0, nil
 }
 
-//Len : len of buffer
+// Len : len of buffer
 func (b *Buff) Len() int {
 	return len(b.datas)
 }
 
-//Bytes : get bytes
+// Bytes : get bytes
 func (b *Buff) Bytes() []byte {
 	return b.datas
 }
 
-//Position : get current postion
+// Position : get current postion
 func (b *Buff) Position() int {
 	return b.position
 }
 
-//SetPosition : set current postion
+// SetPosition : set current postion
 func (b *Buff) SetPosition(pos int) {
 	b.position = pos
 }

--- a/buff_write.go
+++ b/buff_write.go
@@ -2,7 +2,7 @@ package gopdf
 
 import "io"
 
-//WriteUInt32  writes a 32-bit unsigned integer value to w io.Writer
+// WriteUInt32  writes a 32-bit unsigned integer value to w io.Writer
 func WriteUInt32(w io.Writer, v uint) error {
 	a := byte(v >> 24)
 	b := byte(v >> 16)
@@ -15,7 +15,7 @@ func WriteUInt32(w io.Writer, v uint) error {
 	return nil
 }
 
-//WriteUInt16 writes a 16-bit unsigned integer value to w io.Writer
+// WriteUInt16 writes a 16-bit unsigned integer value to w io.Writer
 func WriteUInt16(w io.Writer, v uint) error {
 
 	a := byte(v >> 8)
@@ -27,7 +27,7 @@ func WriteUInt16(w io.Writer, v uint) error {
 	return nil
 }
 
-//WriteTag writes string value to w io.Writer
+// WriteTag writes string value to w io.Writer
 func WriteTag(w io.Writer, tag string) error {
 	b := []byte(tag)
 	_, err := w.Write(b)
@@ -37,7 +37,7 @@ func WriteTag(w io.Writer, tag string) error {
 	return nil
 }
 
-//WriteBytes writes []byte value to w io.Writer
+// WriteBytes writes []byte value to w io.Writer
 func WriteBytes(w io.Writer, data []byte, offset int, count int) error {
 
 	_, err := w.Write(data[offset : offset+count])

--- a/cache_content_text.go
+++ b/cache_content_text.go
@@ -12,10 +12,10 @@ const defaultCoefLineHeight = float64(1)
 const defaultCoefUnderlinePosition = float64(1)
 const defaultcoefUnderlineThickness = float64(1)
 
-//ContentTypeCell cell
+// ContentTypeCell cell
 const ContentTypeCell = 0
 
-//ContentTypeText text
+// ContentTypeText text
 const ContentTypeText = 1
 
 type cacheContentText struct {
@@ -369,12 +369,12 @@ func kern(f *SubsetFontObj, leftRune rune, rightRune rune, leftIndex uint, right
 	return pairVal
 }
 
-//CacheContent Export cacheContent
+// CacheContent Export cacheContent
 type CacheContent struct {
 	cacheContentText
 }
 
-//Setup setup all information for cacheContent
+// Setup setup all information for cacheContent
 func (c *CacheContent) Setup(rectangle *Rect,
 	textColor ICacheColorText,
 	grayFill float64,
@@ -407,7 +407,7 @@ func (c *CacheContent) Setup(rectangle *Rect,
 	}
 }
 
-//WriteTextToContent write text to content
+// WriteTextToContent write text to content
 func (c *CacheContent) WriteTextToContent(text string) {
 	c.cacheContentText.text += text
 }

--- a/catalog_obj.go
+++ b/catalog_obj.go
@@ -5,7 +5,7 @@ import (
 	"io"
 )
 
-//CatalogObj : catalog dictionary
+// CatalogObj : catalog dictionary
 type CatalogObj struct { //impl IObj
 	outlinesObjID int
 }

--- a/cell_option.go
+++ b/cell_option.go
@@ -1,21 +1,21 @@
 package gopdf
 
-//Left left
+// Left left
 const Left = 8 //001000
-//Top top
+// Top top
 const Top = 4 //000100
-//Right right
+// Right right
 const Right = 2 //000010
-//Bottom bottom
+// Bottom bottom
 const Bottom = 1 //000001
-//Center center
+// Center center
 const Center = 16 //010000
-//Middle middle
+// Middle middle
 const Middle = 32 //100000
-//AllBorders allborders
+// AllBorders allborders
 const AllBorders = 15 //001111
 
-//CellOption cell option
+// CellOption cell option
 type CellOption struct {
 	Align                  int //Allows to align the text. Possible values are: Left,Center,Right,Top,Bottom,Middle
 	Border                 int //Indicates if borders must be drawn around the cell. Possible values are: Left, Top, Right, Bottom, ALL

--- a/cid_font_obj.go
+++ b/cid_font_obj.go
@@ -15,7 +15,7 @@ type CIDFontObj struct {
 func (ci *CIDFontObj) init(funcGetRoot func() *GoPdf) {
 }
 
-//SetIndexObjSubfontDescriptor set  indexObjSubfontDescriptor
+// SetIndexObjSubfontDescriptor set  indexObjSubfontDescriptor
 func (ci *CIDFontObj) SetIndexObjSubfontDescriptor(index int) {
 	ci.indexObjSubfontDescriptor = index
 }
@@ -47,7 +47,7 @@ func (ci *CIDFontObj) write(w io.Writer, objID int) error {
 	return nil
 }
 
-//SetPtrToSubsetFontObj set PtrToSubsetFontObj
+// SetPtrToSubsetFontObj set PtrToSubsetFontObj
 func (ci *CIDFontObj) SetPtrToSubsetFontObj(ptr *SubsetFontObj) {
 	ci.PtrToSubsetFontObj = ptr
 }

--- a/config.go
+++ b/config.go
@@ -25,7 +25,7 @@ const (
 	Unit_IN    = UnitIN    // inches
 )
 
-//Config static config
+// Config static config
 type Config struct {
 	Unit       int                 // The unit type to use when composing the document.
 	TrimBox    Box                 // The default trim box for all pages in the document
@@ -34,7 +34,7 @@ type Config struct {
 	Protection PDFProtectionConfig // Protection settings
 }
 
-//PDFProtectionConfig config of pdf protection
+// PDFProtectionConfig config of pdf protection
 type PDFProtectionConfig struct {
 	UseProtection bool
 	Permissions   int

--- a/content_obj.go
+++ b/content_obj.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-//ContentObj content object
+// ContentObj content object
 type ContentObj struct { //impl IObj
 	listCache listCacheContent
 	//text bytes.Buffer
@@ -98,7 +98,7 @@ func (c *ContentObj) getType() string {
 	return "Content"
 }
 
-//AppendStreamText append text
+// AppendStreamText append text
 func (c *ContentObj) AppendStreamText(text string) error {
 
 	//support only CURRENT_FONT_TYPE_SUBSET
@@ -141,7 +141,7 @@ func (c *ContentObj) AppendStreamText(text string) error {
 	return nil
 }
 
-//AppendStreamSubsetFont add stream of text
+// AppendStreamSubsetFont add stream of text
 func (c *ContentObj) AppendStreamSubsetFont(rectangle *Rect, text string, cellOpt CellOption) error {
 
 	textColor := c.getRoot().curr.textColor()
@@ -179,7 +179,7 @@ func (c *ContentObj) AppendStreamSubsetFont(rectangle *Rect, text string, cellOp
 	return nil
 }
 
-//AppendStreamLine append line
+// AppendStreamLine append line
 func (c *ContentObj) AppendStreamLine(x1 float64, y1 float64, x2 float64, y2 float64, lineOpts lineOptions) {
 	//h := c.getRoot().config.PageSize.H
 	//c.stream.WriteString(fmt.Sprintf("%0.2f %0.2f m %0.2f %0.2f l s\n", x1, h-y1, x2, h-y2))
@@ -193,7 +193,7 @@ func (c *ContentObj) AppendStreamLine(x1 float64, y1 float64, x2 float64, y2 flo
 	c.listCache.append(&cache)
 }
 
-//AppendStreamImportedTemplate append imported template
+// AppendStreamImportedTemplate append imported template
 func (c *ContentObj) AppendStreamImportedTemplate(tplName string, scaleX float64, scaleY float64, tX float64, tY float64) {
 	var cache cacheContentImportedTemplate
 	cache.pageHeight = c.getRoot().curr.pageSize.H
@@ -210,7 +210,7 @@ func (c *ContentObj) AppendStreamRectangle(opts DrawableRectOptions) {
 	c.listCache.append(cache)
 }
 
-//AppendStreamOval append oval
+// AppendStreamOval append oval
 func (c *ContentObj) AppendStreamOval(x1 float64, y1 float64, x2 float64, y2 float64) {
 	var cache cacheContentOval
 	cache.pageHeight = c.getRoot().curr.pageSize.H
@@ -221,15 +221,15 @@ func (c *ContentObj) AppendStreamOval(x1 float64, y1 float64, x2 float64, y2 flo
 	c.listCache.append(&cache)
 }
 
-//AppendStreamCurve draw curve
-// - x0, y0: Start point
-// - x1, y1: Control point 1
-// - x2, y2: Control point 2
-// - x3, y3: End point
-// - style: Style of rectangule (draw and/or fill: D, F, DF, FD)
-//		D or empty string: draw. This is the default value.
-//		F: fill
-//		DF or FD: draw and fill
+// AppendStreamCurve draw curve
+//   - x0, y0: Start point
+//   - x1, y1: Control point 1
+//   - x2, y2: Control point 2
+//   - x3, y3: End point
+//   - style: Style of rectangule (draw and/or fill: D, F, DF, FD)
+//     D or empty string: draw. This is the default value.
+//     F: fill
+//     DF or FD: draw and fill
 func (c *ContentObj) AppendStreamCurve(x0 float64, y0 float64, x1 float64, y1 float64, x2 float64, y2 float64, x3 float64, y3 float64, style string) {
 	var cache cacheContentCurve
 	cache.pageHeight = c.getRoot().curr.pageSize.H
@@ -245,14 +245,14 @@ func (c *ContentObj) AppendStreamCurve(x0 float64, y0 float64, x1 float64, y1 fl
 	c.listCache.append(&cache)
 }
 
-//AppendStreamSetLineWidth : set line width
+// AppendStreamSetLineWidth : set line width
 func (c *ContentObj) AppendStreamSetLineWidth(w float64) {
 	var cache cacheContentLineWidth
 	cache.width = w
 	c.listCache.append(&cache)
 }
 
-//AppendStreamSetLineType : Set linetype [solid, dashed, dotted]
+// AppendStreamSetLineType : Set linetype [solid, dashed, dotted]
 func (c *ContentObj) AppendStreamSetLineType(t string) {
 	var cache cacheContentLineType
 	cache.lineType = t
@@ -260,7 +260,7 @@ func (c *ContentObj) AppendStreamSetLineType(t string) {
 
 }
 
-//AppendStreamSetGrayFill  set the grayscale fills
+// AppendStreamSetGrayFill  set the grayscale fills
 func (c *ContentObj) AppendStreamSetGrayFill(w float64) {
 	w = fixRange10(w)
 	var cache cacheContentGray
@@ -269,7 +269,7 @@ func (c *ContentObj) AppendStreamSetGrayFill(w float64) {
 	c.listCache.append(&cache)
 }
 
-//AppendStreamSetGrayStroke  set the grayscale stroke
+// AppendStreamSetGrayStroke  set the grayscale stroke
 func (c *ContentObj) AppendStreamSetGrayStroke(w float64) {
 	w = fixRange10(w)
 	var cache cacheContentGray
@@ -278,7 +278,7 @@ func (c *ContentObj) AppendStreamSetGrayStroke(w float64) {
 	c.listCache.append(&cache)
 }
 
-//AppendStreamSetColorStroke  set the color stroke
+// AppendStreamSetColorStroke  set the color stroke
 func (c *ContentObj) AppendStreamSetColorStroke(r uint8, g uint8, b uint8) {
 	var cache cacheContentColorRGB
 	cache.colorType = colorTypeStrokeRGB
@@ -288,7 +288,7 @@ func (c *ContentObj) AppendStreamSetColorStroke(r uint8, g uint8, b uint8) {
 	c.listCache.append(&cache)
 }
 
-//AppendStreamSetColorFill  set the color fill
+// AppendStreamSetColorFill  set the color fill
 func (c *ContentObj) AppendStreamSetColorFill(r uint8, g uint8, b uint8) {
 	var cache cacheContentColorRGB
 	cache.colorType = colorTypeFillRGB
@@ -298,7 +298,7 @@ func (c *ContentObj) AppendStreamSetColorFill(r uint8, g uint8, b uint8) {
 	c.listCache.append(&cache)
 }
 
-//AppendStreamSetColorStrokeCMYK  set the color stroke in CMYK color mode
+// AppendStreamSetColorStrokeCMYK  set the color stroke in CMYK color mode
 func (c *ContentObj) AppendStreamSetColorStrokeCMYK(cy, m, y, k uint8) {
 	var cache cacheContentColorCMYK
 	cache.colorType = colorTypeStrokeCMYK
@@ -309,7 +309,7 @@ func (c *ContentObj) AppendStreamSetColorStrokeCMYK(cy, m, y, k uint8) {
 	c.listCache.append(&cache)
 }
 
-//AppendStreamSetColorFillCMYK  set the color fill in CMYK color mode
+// AppendStreamSetColorFillCMYK  set the color fill in CMYK color mode
 func (c *ContentObj) AppendStreamSetColorFillCMYK(cy, m, y, k uint8) {
 	var cache cacheContentColorCMYK
 	cache.colorType = colorTypeFillCMYK
@@ -347,13 +347,13 @@ func (c *ContentObj) GetCacheContentImage(index int, opts ImageOptions) *cacheCo
 	}
 }
 
-//AppendStreamImage append image
+// AppendStreamImage append image
 func (c *ContentObj) AppendStreamImage(index int, opts ImageOptions) {
 	cache := c.GetCacheContentImage(index, opts)
 	c.listCache.append(cache)
 }
 
-//AppendStreamPolygon append polygon
+// AppendStreamPolygon append polygon
 func (c *ContentObj) AppendStreamPolygon(points []Point, style string, opts polygonOptions) {
 	var cache cacheContentPolygon
 	cache.points = points
@@ -379,12 +379,12 @@ func (c *ContentObj) appendRotateReset() {
 	c.listCache.append(&cache)
 }
 
-//ContentObjCalTextHeight : calculates height of text.
+// ContentObjCalTextHeight : calculates height of text.
 func ContentObjCalTextHeight(fontsize int) float64 {
 	return ContentObjCalTextHeightPrecise(float64(fontsize))
 }
 
-//ContentObjCalTextHeightPrecise : like ContentObjCalTextHeight,
+// ContentObjCalTextHeightPrecise : like ContentObjCalTextHeight,
 // but fontsize float64
 func ContentObjCalTextHeightPrecise(fontsize float64) float64 {
 	return (float64(fontsize) * 0.7)

--- a/current.go
+++ b/current.go
@@ -1,6 +1,6 @@
 package gopdf
 
-//Current current state
+// Current current state
 type Current struct {
 	setXCount int //many times we go func SetX()
 	X         float64

--- a/device_rgb_obj.go
+++ b/device_rgb_obj.go
@@ -5,7 +5,7 @@ import (
 	"io"
 )
 
-//DeviceRGBObj  DeviceRGB
+// DeviceRGBObj  DeviceRGB
 type DeviceRGBObj struct {
 	data    []byte
 	getRoot func() *GoPdf
@@ -23,7 +23,7 @@ func (d *DeviceRGBObj) getType() string {
 	return "devicergb"
 }
 
-//สร้าง ข้อมูลใน pdf
+// สร้าง ข้อมูลใน pdf
 func (d *DeviceRGBObj) write(w io.Writer, objID int) error {
 
 	io.WriteString(w, "<<\n")

--- a/encryption_obj.go
+++ b/encryption_obj.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-//EncryptionObj  encryption object res
+// EncryptionObj  encryption object res
 type EncryptionObj struct {
 	uValue []byte //U entry in pdf document
 	oValue []byte //O entry in pdf document

--- a/font_obj.go
+++ b/font_obj.go
@@ -5,7 +5,7 @@ import (
 	"io"
 )
 
-//FontObj font obj
+// FontObj font obj
 type FontObj struct {
 	Family string
 	//Style string

--- a/font_option.go
+++ b/font_option.go
@@ -4,13 +4,13 @@ import (
 	"strings"
 )
 
-//Regular - font style regular
+// Regular - font style regular
 const Regular = 0 //000000
-//Italic - font style italic
+// Italic - font style italic
 const Italic = 1 //000001
-//Bold - font style bold
+// Bold - font style bold
 const Bold = 2 //000010
-//Underline - font style underline
+// Underline - font style underline
 const Underline = 4 //000100
 
 func getConvertedStyle(fontStyle string) (style int) {

--- a/fontmaker/core/fontmaker.go
+++ b/fontmaker/core/fontmaker.go
@@ -13,20 +13,20 @@ import (
 	"strings"
 )
 
-//ErrFontLicenseDoesNotAllowEmbedding Font license does not allow embedding
+// ErrFontLicenseDoesNotAllowEmbedding Font license does not allow embedding
 var ErrFontLicenseDoesNotAllowEmbedding = errors.New("Font license does not allow embedding")
 
-//FontMaker font maker
+// FontMaker font maker
 type FontMaker struct {
 	results []string
 }
 
-//GetResults get result
+// GetResults get result
 func (f *FontMaker) GetResults() []string {
 	return f.results
 }
 
-//NewFontMaker new FontMaker
+// NewFontMaker new FontMaker
 func NewFontMaker() *FontMaker {
 	return new(FontMaker)
 }

--- a/fontmaker/core/kern_table.go
+++ b/fontmaker/core/kern_table.go
@@ -1,19 +1,19 @@
 package core
 
-//KernTable https://www.microsoft.com/typography/otspec/kern.htm
+// KernTable https://www.microsoft.com/typography/otspec/kern.htm
 type KernTable struct {
 	Version uint //for debug
 	NTables uint //for debug
 	Kerning KernMap
 }
 
-//KernMap kerning map   map[left]KernValue
+// KernMap kerning map   map[left]KernValue
 type KernMap map[uint]KernValue
 
-//KernValue kerning values  map[right]value
+// KernValue kerning values  map[right]value
 type KernValue map[uint]int16
 
-//ValueByRight  get value by right
+// ValueByRight  get value by right
 func (k KernValue) ValueByRight(right uint) (bool, int16) {
 	if val, ok := k[uint(right)]; ok {
 		return true, val

--- a/fontmaker/core/ttfparser.go
+++ b/fontmaker/core/ttfparser.go
@@ -19,7 +19,7 @@ var ERROR_UNEXPECTED_SUBTABLE_FORMAT = errors.New("Unexpected subtable format")
 var ERROR_INCORRECT_MAGIC_NUMBER = errors.New("Incorrect magic number")
 var ERROR_POSTSCRIPT_NAME_NOT_FOUND = errors.New("PostScript name not found")
 
-//TTFParser true type font parser
+// TTFParser true type font parser
 type TTFParser struct {
 	tables map[string]TableDirectoryEntry
 	//head
@@ -83,22 +83,22 @@ type TTFParser struct {
 var Symbolic = 1 << 2
 var Nonsymbolic = (1 << 5)
 
-//Kern get KernTable
+// Kern get KernTable
 func (t *TTFParser) Kern() *KernTable {
 	return t.kern
 }
 
-//UnderlinePosition postion of underline
+// UnderlinePosition postion of underline
 func (t *TTFParser) UnderlinePosition() int {
 	return t.underlinePosition
 }
 
-//GroupingTables get cmap format12 grouping table
+// GroupingTables get cmap format12 grouping table
 func (t *TTFParser) GroupingTables() []CmapFormat12GroupingTable {
 	return t.groupingTables
 }
 
-//UnderlineThickness thickness of underline
+// UnderlineThickness thickness of underline
 func (t *TTFParser) UnderlineThickness() int {
 	return t.underlineThickness
 }
@@ -167,12 +167,12 @@ func (t *TTFParser) TypoDescender() int {
 	return t.typoDescender
 }
 
-//CapHeight https://en.wikipedia.org/wiki/Cap_height
+// CapHeight https://en.wikipedia.org/wiki/Cap_height
 func (t *TTFParser) CapHeight() int {
 	return t.capHeight
 }
 
-//NumGlyphs number of glyph
+// NumGlyphs number of glyph
 func (t *TTFParser) NumGlyphs() uint {
 	return t.numGlyphs
 }
@@ -197,12 +197,12 @@ func (t *TTFParser) GetTables() map[string]TableDirectoryEntry {
 	return t.tables
 }
 
-//SetUseKerning set useKerning must set before Parse
+// SetUseKerning set useKerning must set before Parse
 func (t *TTFParser) SetUseKerning(use bool) {
 	t.useKerning = use
 }
 
-//Parse parse
+// Parse parse
 func (t *TTFParser) Parse(filepath string) error {
 	data, err := ioutil.ReadFile(filepath)
 	if err != nil {
@@ -211,7 +211,7 @@ func (t *TTFParser) Parse(filepath string) error {
 	return t.ParseFontData(data)
 }
 
-//ParseByReader parse by io.reader
+// ParseByReader parse by io.reader
 func (t *TTFParser) ParseByReader(rd io.Reader) error {
 	fontData, err := ioutil.ReadAll(rd)
 	if err != nil {
@@ -324,7 +324,7 @@ func (t *TTFParser) FontData() []byte {
 	return t.cachedFontData
 }
 
-//ParseLoca parse loca table https://www.microsoft.com/typography/otspec/loca.htm
+// ParseLoca parse loca table https://www.microsoft.com/typography/otspec/loca.htm
 func (t *TTFParser) ParseLoca(fd *bytes.Reader) error {
 
 	t.IsShortIndex = false
@@ -366,7 +366,7 @@ func (t *TTFParser) ParseLoca(fd *bytes.Reader) error {
 	return nil
 }
 
-//ParsePost parse post table https://www.microsoft.com/typography/otspec/post.htm
+// ParsePost parse post table https://www.microsoft.com/typography/otspec/post.htm
 func (t *TTFParser) ParsePost(fd *bytes.Reader) error {
 
 	err := t.Seek(fd, "post")
@@ -408,7 +408,7 @@ func (t *TTFParser) ParsePost(fd *bytes.Reader) error {
 	return nil
 }
 
-//ParseOS2 parse OS2 table https://www.microsoft.com/typography/otspec/OS2.htm
+// ParseOS2 parse OS2 table https://www.microsoft.com/typography/otspec/OS2.htm
 func (t *TTFParser) ParseOS2(fd *bytes.Reader) error {
 	err := t.Seek(fd, "OS/2")
 	if err != nil {
@@ -492,7 +492,7 @@ func (t *TTFParser) ParseOS2(fd *bytes.Reader) error {
 	return nil
 }
 
-//ParseName parse name table https://www.microsoft.com/typography/otspec/name.htm
+// ParseName parse name table https://www.microsoft.com/typography/otspec/name.htm
 func (t *TTFParser) ParseName(fd *bytes.Reader) error {
 
 	//$this->Seek('name');
@@ -586,7 +586,7 @@ func (t *TTFParser) PregReplace(pattern string, replacement string, subject stri
 	return str, nil
 }
 
-//ParseCmap parse cmap table format 4 https://www.microsoft.com/typography/otspec/cmap.htm
+// ParseCmap parse cmap table format 4 https://www.microsoft.com/typography/otspec/cmap.htm
 func (t *TTFParser) ParseCmap(fd *bytes.Reader) error {
 	t.Seek(fd, "cmap")
 	t.Skip(fd, 2) // version
@@ -770,7 +770,7 @@ func (t *TTFParser) FTell(fd *bytes.Reader) (uint, error) {
 	return uint(offset), err
 }
 
-//ParseHmtx parse hmtx table  https://www.microsoft.com/typography/otspec/hmtx.htm
+// ParseHmtx parse hmtx table  https://www.microsoft.com/typography/otspec/hmtx.htm
 func (t *TTFParser) ParseHmtx(fd *bytes.Reader) error {
 
 	t.Seek(fd, "hmtx")
@@ -814,7 +814,7 @@ func (t *TTFParser) ArrayPadUint(arr []uint, size uint, val uint) ([]uint, error
 	return result, nil
 }
 
-//ParseHead parse head table  https://www.microsoft.com/typography/otspec/Head.htm
+// ParseHead parse head table  https://www.microsoft.com/typography/otspec/Head.htm
 func (t *TTFParser) ParseHead(fd *bytes.Reader) error {
 
 	err := t.Seek(fd, "head")
@@ -883,7 +883,7 @@ func (t *TTFParser) ParseHead(fd *bytes.Reader) error {
 	return nil
 }
 
-//ParseHhea parse hhea table  https://www.microsoft.com/typography/otspec/hhea.htm
+// ParseHhea parse hhea table  https://www.microsoft.com/typography/otspec/hhea.htm
 func (t *TTFParser) ParseHhea(fd *bytes.Reader) error {
 
 	err := t.Seek(fd, "hhea")
@@ -919,7 +919,7 @@ func (t *TTFParser) ParseHhea(fd *bytes.Reader) error {
 	return nil
 }
 
-//ParseMaxp parse maxp table  https://www.microsoft.com/typography/otspec/Maxp.htm
+// ParseMaxp parse maxp table  https://www.microsoft.com/typography/otspec/Maxp.htm
 func (t *TTFParser) ParseMaxp(fd *bytes.Reader) error {
 	err := t.Seek(fd, "maxp")
 	if err != nil {
@@ -936,10 +936,10 @@ func (t *TTFParser) ParseMaxp(fd *bytes.Reader) error {
 	return nil
 }
 
-//ErrTableNotFound error table not found
+// ErrTableNotFound error table not found
 var ErrTableNotFound = errors.New("table not found")
 
-//Seek seek by tag
+// Seek seek by tag
 func (t *TTFParser) Seek(fd *bytes.Reader, tag string) error {
 	table, ok := t.tables[tag]
 	if !ok {
@@ -953,12 +953,12 @@ func (t *TTFParser) Seek(fd *bytes.Reader, tag string) error {
 	return nil
 }
 
-//BytesToString convert bytes to string
+// BytesToString convert bytes to string
 func (t *TTFParser) BytesToString(b []byte) string {
 	return string(b) //strings.TrimSpace(string(b))
 }
 
-//ReadUShort read ushort
+// ReadUShort read ushort
 func (t *TTFParser) ReadUShort(fd *bytes.Reader) (uint, error) {
 	buff, err := t.Read(fd, 2)
 	if err != nil {
@@ -968,7 +968,7 @@ func (t *TTFParser) ReadUShort(fd *bytes.Reader) (uint, error) {
 	return uint(n), nil
 }
 
-//ReadShort read short
+// ReadShort read short
 func (t *TTFParser) ReadShort(fd *bytes.Reader) (int, error) {
 	u, err := t.ReadUShort(fd)
 	if err != nil {
@@ -984,7 +984,7 @@ func (t *TTFParser) ReadShort(fd *bytes.Reader) (int, error) {
 	return v, nil
 }
 
-//ReadShortInt16 read short return int16
+// ReadShortInt16 read short return int16
 func (t *TTFParser) ReadShortInt16(fd *bytes.Reader) (int16, error) {
 	n, err := t.ReadShort(fd)
 	if err != nil {
@@ -993,7 +993,7 @@ func (t *TTFParser) ReadShortInt16(fd *bytes.Reader) (int16, error) {
 	return int16(n), nil
 }
 
-//ReadULong read ulong
+// ReadULong read ulong
 func (t *TTFParser) ReadULong(fd *bytes.Reader) (uint, error) {
 	buff, err := t.Read(fd, 4)
 	if err != nil {
@@ -1003,7 +1003,7 @@ func (t *TTFParser) ReadULong(fd *bytes.Reader) (uint, error) {
 	return uint(n), nil
 }
 
-//Skip skip
+// Skip skip
 func (t *TTFParser) Skip(fd *bytes.Reader, length int) error {
 	_, err := fd.Seek(int64(length), 1)
 	if err != nil {
@@ -1012,7 +1012,7 @@ func (t *TTFParser) Skip(fd *bytes.Reader, length int) error {
 	return nil
 }
 
-//Read read
+// Read read
 func (t *TTFParser) Read(fd *bytes.Reader, length int) ([]byte, error) {
 	buff := make([]byte, length)
 	readlength, err := fd.Read(buff)

--- a/fontmaker/core/ttfparser_cmap_other_format.go
+++ b/fontmaker/core/ttfparser_cmap_other_format.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 )
 
-//ParseCmapFormat12 parse cmap table format 12 https://www.microsoft.com/typography/otspec/cmap.htm
+// ParseCmapFormat12 parse cmap table format 12 https://www.microsoft.com/typography/otspec/cmap.htm
 func (t *TTFParser) ParseCmapFormat12(fd *bytes.Reader) (bool, error) {
 
 	t.Seek(fd, "cmap")

--- a/fontmaker/core/ttfparser_kern.go
+++ b/fontmaker/core/ttfparser_kern.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-//Parsekern parse kerning table  https://www.microsoft.com/typography/otspec/kern.htm
+// Parsekern parse kerning table  https://www.microsoft.com/typography/otspec/kern.htm
 func (t *TTFParser) Parsekern(fd *bytes.Reader) error {
 
 	t.kern = nil //clear

--- a/func_kern_override.go
+++ b/func_kern_override.go
@@ -1,6 +1,6 @@
 package gopdf
 
-//FuncKernOverride  return your custome pair value
+// FuncKernOverride  return your custome pair value
 type FuncKernOverride func(
 	leftRune rune,
 	rightRune rune,

--- a/image_holder.go
+++ b/image_holder.go
@@ -8,28 +8,28 @@ import (
 	"io/ioutil"
 )
 
-//ImageHolder hold image data
+// ImageHolder hold image data
 type ImageHolder interface {
 	ID() string
 	io.Reader
 }
 
-//ImageHolderByBytes create ImageHolder by []byte
+// ImageHolderByBytes create ImageHolder by []byte
 func ImageHolderByBytes(b []byte) (ImageHolder, error) {
 	return newImageBuff(b)
 }
 
-//ImageHolderByPath create ImageHolder by image path
+// ImageHolderByPath create ImageHolder by image path
 func ImageHolderByPath(path string) (ImageHolder, error) {
 	return newImageBuffByPath(path)
 }
 
-//ImageHolderByReader create ImageHolder by io.Reader
+// ImageHolderByReader create ImageHolder by io.Reader
 func ImageHolderByReader(r io.Reader) (ImageHolder, error) {
 	return newImageBuffByReader(r)
 }
 
-//imageBuff image holder (impl ImageHolder)
+// imageBuff image holder (impl ImageHolder)
 type imageBuff struct {
 	id string
 	bytes.Buffer

--- a/image_obj.go
+++ b/image_obj.go
@@ -15,7 +15,7 @@ import (
 	"os"
 )
 
-//ImageObj image object
+// ImageObj image object
 type ImageObj struct {
 	//imagepath string
 	IsMask        bool
@@ -116,7 +116,7 @@ func (i *ImageObj) getType() string {
 	return "Image"
 }
 
-//SetImagePath set image path
+// SetImagePath set image path
 func (i *ImageObj) SetImagePath(path string) error {
 
 	file, err := os.Open(path)
@@ -132,7 +132,7 @@ func (i *ImageObj) SetImagePath(path string) error {
 	return nil
 }
 
-//SetImage set image
+// SetImage set image
 func (i *ImageObj) SetImage(r io.Reader) error {
 
 	data, err := ioutil.ReadAll(r)
@@ -144,7 +144,7 @@ func (i *ImageObj) SetImage(r io.Reader) error {
 	return nil
 }
 
-//GetRect get rect of img
+// GetRect get rect of img
 func (i *ImageObj) GetRect() *Rect {
 
 	rect, err := i.getRect()
@@ -154,7 +154,7 @@ func (i *ImageObj) GetRect() *Rect {
 	return rect
 }
 
-//GetRect get rect of img
+// GetRect get rect of img
 func (i *ImageObj) getRect() (*Rect, error) {
 
 	i.rawImgReader.Seek(0, 0)
@@ -199,7 +199,7 @@ func (i *ImageObj) parse() error {
 	return nil
 }
 
-//Parse parse img
+// Parse parse img
 func (i *ImageObj) Parse() error {
 	return i.parse()
 }

--- a/image_obj_parse.go
+++ b/image_obj_parse.go
@@ -504,7 +504,7 @@ func isDeviceRGB(formatname string, img *image.Image) bool {
 	return false
 }
 
-//ImgReactagleToWH  Rectangle to W and H
+// ImgReactagleToWH  Rectangle to W and H
 func ImgReactagleToWH(imageRect image.Rectangle) (float64, float64) {
 	k := 1
 	w := -128 //init

--- a/imported_obj.go
+++ b/imported_obj.go
@@ -4,7 +4,7 @@ import (
 	"io"
 )
 
-//ImportedObj : imported object
+// ImportedObj : imported object
 type ImportedObj struct { //impl IObj
 	Data string
 }

--- a/iobj.go
+++ b/iobj.go
@@ -4,7 +4,7 @@ import (
 	"io"
 )
 
-//IObj inteface for all pdf object
+// IObj inteface for all pdf object
 type IObj interface {
 	init(func() *GoPdf)
 	getType() string

--- a/map_of_character_To_glyph_index.go
+++ b/map_of_character_To_glyph_index.go
@@ -1,20 +1,20 @@
 package gopdf
 
-//MapOfCharacterToGlyphIndex map of CharacterToGlyphIndex
+// MapOfCharacterToGlyphIndex map of CharacterToGlyphIndex
 type MapOfCharacterToGlyphIndex struct {
 	keyIndexs map[rune]int //for search index in keys
 	Keys      []rune
 	Vals      []uint
 }
 
-//NewMapOfCharacterToGlyphIndex new CharacterToGlyphIndex
+// NewMapOfCharacterToGlyphIndex new CharacterToGlyphIndex
 func NewMapOfCharacterToGlyphIndex() *MapOfCharacterToGlyphIndex {
 	var m MapOfCharacterToGlyphIndex
 	m.keyIndexs = make(map[rune]int)
 	return &m
 }
 
-//KeyExists key is exists?
+// KeyExists key is exists?
 func (m *MapOfCharacterToGlyphIndex) KeyExists(k rune) bool {
 	/*for _, key := range m.Keys {
 		if k == key {
@@ -27,14 +27,14 @@ func (m *MapOfCharacterToGlyphIndex) KeyExists(k rune) bool {
 	return false
 }
 
-//Set set key and value to map
+// Set set key and value to map
 func (m *MapOfCharacterToGlyphIndex) Set(k rune, v uint) {
 	m.keyIndexs[k] = len(m.Keys)
 	m.Keys = append(m.Keys, k)
 	m.Vals = append(m.Vals, v)
 }
 
-//Index get index by key
+// Index get index by key
 func (m *MapOfCharacterToGlyphIndex) Index(k rune) (int, bool) {
 	/*for i, key := range m.Keys {
 		if k == key {
@@ -47,7 +47,7 @@ func (m *MapOfCharacterToGlyphIndex) Index(k rune) (int, bool) {
 	return -1, false
 }
 
-//Val get value by Key
+// Val get value by Key
 func (m *MapOfCharacterToGlyphIndex) Val(k rune) (uint, bool) {
 	i, ok := m.Index(k)
 	if !ok {
@@ -56,12 +56,12 @@ func (m *MapOfCharacterToGlyphIndex) Val(k rune) (uint, bool) {
 	return m.Vals[i], true
 }
 
-//AllKeys get keys
+// AllKeys get keys
 func (m *MapOfCharacterToGlyphIndex) AllKeys() []rune {
 	return m.Keys
 }
 
-//AllVals get all values
+// AllVals get all values
 func (m *MapOfCharacterToGlyphIndex) AllVals() []uint {
 	return m.Vals
 }

--- a/outlines_obj.go
+++ b/outlines_obj.go
@@ -5,7 +5,7 @@ import (
 	"io"
 )
 
-//OutlinesObj : outlines dictionary
+// OutlinesObj : outlines dictionary
 type OutlinesObj struct { //impl IObj
 	getRoot func() *GoPdf
 

--- a/page_obj.go
+++ b/page_obj.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-//PageObj pdf page object
+// PageObj pdf page object
 type PageObj struct { //impl IObj
 	Contents        string
 	ResourcesRelate string

--- a/page_option.go
+++ b/page_option.go
@@ -1,6 +1,6 @@
 package gopdf
 
-//PageOption option of page
+// PageOption option of page
 type PageOption struct {
 	TrimBox  *Box
 	PageSize *Rect

--- a/pages_obj.go
+++ b/pages_obj.go
@@ -5,7 +5,7 @@ import (
 	"io"
 )
 
-//PagesObj pdf pages object
+// PagesObj pdf pages object
 type PagesObj struct { //impl IObj
 	PageCount int
 	Kids      string

--- a/pdf_dictionary_obj.go
+++ b/pdf_dictionary_obj.go
@@ -10,7 +10,7 @@ import (
 	"github.com/signintech/gopdf/fontmaker/core"
 )
 
-//EntrySelectors entry selectors
+// EntrySelectors entry selectors
 var EntrySelectors = []int{
 	0, 0, 1, 1, 2, 2,
 	2, 2, 3, 3, 3, 3,
@@ -19,10 +19,10 @@ var EntrySelectors = []int{
 	4, 4, 4, 4, 4, 4, 4,
 }
 
-//ErrNotSupportShortIndexYet not suport none short index yet
+// ErrNotSupportShortIndexYet not suport none short index yet
 var ErrNotSupportShortIndexYet = errors.New("not suport none short index yet")
 
-//PdfDictionaryObj pdf dictionary object
+// PdfDictionaryObj pdf dictionary object
 type PdfDictionaryObj struct {
 	PtrToSubsetFontObj *SubsetFontObj
 	//getRoot            func() *GoPdf
@@ -83,12 +83,12 @@ func (p *PdfDictionaryObj) getType() string {
 	return "PdfDictionary"
 }
 
-//SetPtrToSubsetFontObj set subsetFontObj pointer
+// SetPtrToSubsetFontObj set subsetFontObj pointer
 func (p *PdfDictionaryObj) SetPtrToSubsetFontObj(ptr *SubsetFontObj) {
 	p.PtrToSubsetFontObj = ptr
 }
 
-//distinctInts distinct number in nn ( value in nn must sorted )
+// distinctInts distinct number in nn ( value in nn must sorted )
 func (p *PdfDictionaryObj) distinctInts(nn []int) []int {
 	var buff []int
 	var prev = -1
@@ -302,8 +302,8 @@ func (p *PdfDictionaryObj) completeGlyphClosure(mapOfglyphs *MapOfCharacterToGly
 	return glyphArray
 }
 
-//AddCompositeGlyphs add composite glyph
-//composite glyph is a Unicode entity that can be defined as a sequence of one or more other characters.
+// AddCompositeGlyphs add composite glyph
+// composite glyph is a Unicode entity that can be defined as a sequence of one or more other characters.
 func (p *PdfDictionaryObj) AddCompositeGlyphs(glyphArray *[]int, glyph int) {
 	start := p.GetOffset(int(glyph))
 	if start == p.GetOffset(int(glyph)+1) {
@@ -362,7 +362,7 @@ const arg1and2areWords = 1
 const xAndYScale = 64
 const twoByTwo = 128
 
-//GetOffset get offset from glyf table
+// GetOffset get offset from glyf table
 func (p *PdfDictionaryObj) GetOffset(glyph int) int {
 	ttfp := p.PtrToSubsetFontObj.GetTTFParser()
 	glyf := ttfp.GetTables()["glyf"]
@@ -370,7 +370,7 @@ func (p *PdfDictionaryObj) GetOffset(glyph int) int {
 	return offset
 }
 
-//CheckSum check sum
+// CheckSum check sum
 func CheckSum(data []byte) uint {
 
 	var byte3, byte2, byte1, byte0 uint64

--- a/pdf_info_obj.go
+++ b/pdf_info_obj.go
@@ -2,7 +2,7 @@ package gopdf
 
 import "time"
 
-//PdfInfo Document Information Dictionary
+// PdfInfo Document Information Dictionary
 type PdfInfo struct {
 	Title        string    //The document’s title
 	Author       string    //The name of the person who created the document.

--- a/pdf_protection.go
+++ b/pdf_protection.go
@@ -24,7 +24,7 @@ var protectionPadding = []byte{
 	0x2E, 0x2E, 0x00, 0xB6, 0xD0, 0x68, 0x3E, 0x80, 0x2F, 0x0C, 0xA9, 0xFE, 0x64, 0x53, 0x69, 0x7A,
 }
 
-//PDFProtection protection in pdf
+// PDFProtection protection in pdf
 type PDFProtection struct {
 	encrypted bool   //whether document is protected
 	uValue    []byte //U entry in pdf document
@@ -34,7 +34,7 @@ type PDFProtection struct {
 	encryptionKey []byte
 }
 
-//SetProtection set protection infomation
+// SetProtection set protection infomation
 func (p *PDFProtection) SetProtection(permissions int, userPass []byte, ownerPass []byte) error {
 	return p.setProtection(permissions, userPass, ownerPass)
 }
@@ -71,7 +71,7 @@ func (p *PDFProtection) generateEncryptionKey(userPass []byte, ownerPass []byte,
 	return nil
 }
 
-//EncryptionObj get Encryption Object
+// EncryptionObj get Encryption Object
 func (p *PDFProtection) EncryptionObj() *EncryptionObj {
 	return p.encryptionObj()
 }
@@ -123,7 +123,7 @@ func (p *PDFProtection) randomPass(strlen int) []byte {
 	return result
 }
 
-//Objectkey create object key from ObjID
+// Objectkey create object key from ObjID
 func (p *PDFProtection) Objectkey(objID int) []byte {
 	return p.objectkey(objID)
 }

--- a/point.go
+++ b/point.go
@@ -1,6 +1,6 @@
 package gopdf
 
-//Point a point in a two-dimensional
+// Point a point in a two-dimensional
 type Point struct {
 	X float64
 	Y float64

--- a/smask_obj.go
+++ b/smask_obj.go
@@ -13,7 +13,7 @@ const (
 	SMaskLuminositySubtype = "/Luminosity"
 )
 
-//SMask smask
+// SMask smask
 type SMask struct {
 	imgInfo
 	data []byte

--- a/strhelper.go
+++ b/strhelper.go
@@ -5,12 +5,12 @@ import (
 	"strings"
 )
 
-//StrHelperGetStringWidth get string width
+// StrHelperGetStringWidth get string width
 func StrHelperGetStringWidth(str string, fontSize int, ifont IFont) float64 {
 	return StrHelperGetStringWidthPrecise(str, float64(fontSize), ifont)
 }
 
-//StrHelperGetStringWidthPrecise get string width with real number fontSize
+// StrHelperGetStringWidthPrecise get string width with real number fontSize
 func StrHelperGetStringWidthPrecise(str string, fontSize float64, ifont IFont) float64 {
 
 	w := 0
@@ -24,14 +24,14 @@ func StrHelperGetStringWidthPrecise(str string, fontSize float64, ifont IFont) f
 	return float64(w) * (float64(fontSize) / 1000.0)
 }
 
-//CreateEmbeddedFontSubsetName create Embedded font (subset font) name
+// CreateEmbeddedFontSubsetName create Embedded font (subset font) name
 func CreateEmbeddedFontSubsetName(name string) string {
 	name = strings.Replace(name, " ", "+", -1)
 	name = strings.Replace(name, "/", "+", -1)
 	return name
 }
 
-//ReadShortFromByte read short from byte array
+// ReadShortFromByte read short from byte array
 func ReadShortFromByte(data []byte, offset int) (int64, int) {
 	buff := data[offset : offset+2]
 	num := big.NewInt(0)
@@ -46,7 +46,7 @@ func ReadShortFromByte(data []byte, offset int) (int64, int) {
 	return v, 2
 }
 
-//ReadUShortFromByte read ushort from byte array
+// ReadUShortFromByte read ushort from byte array
 func ReadUShortFromByte(data []byte, offset int) (uint64, int) {
 	buff := data[offset : offset+2]
 	num := big.NewInt(0)

--- a/subfont_descriptor_obj.go
+++ b/subfont_descriptor_obj.go
@@ -7,7 +7,7 @@ import (
 	"github.com/signintech/gopdf/fontmaker/core"
 )
 
-//SubfontDescriptorObj pdf subfont descriptorObj object
+// SubfontDescriptorObj pdf subfont descriptorObj object
 type SubfontDescriptorObj struct {
 	PtrToSubsetFontObj    *SubsetFontObj
 	indexObjPdfDictionary int
@@ -43,17 +43,17 @@ func (s *SubfontDescriptorObj) write(w io.Writer, objID int) error {
 	return nil
 }
 
-//SetIndexObjPdfDictionary set PdfDictionary pointer
+// SetIndexObjPdfDictionary set PdfDictionary pointer
 func (s *SubfontDescriptorObj) SetIndexObjPdfDictionary(index int) {
 	s.indexObjPdfDictionary = index
 }
 
-//SetPtrToSubsetFontObj set SubsetFont pointer
+// SetPtrToSubsetFontObj set SubsetFont pointer
 func (s *SubfontDescriptorObj) SetPtrToSubsetFontObj(ptr *SubsetFontObj) {
 	s.PtrToSubsetFontObj = ptr
 }
 
-//DesignUnitsToPdf convert unit
+// DesignUnitsToPdf convert unit
 func DesignUnitsToPdf(val int, unitsPerEm uint) int {
 	return core.Round(float64(float64(val) * 1000.00 / float64(unitsPerEm)))
 }

--- a/subset_font_obj.go
+++ b/subset_font_obj.go
@@ -8,13 +8,13 @@ import (
 	"github.com/signintech/gopdf/fontmaker/core"
 )
 
-//ErrCharNotFound char not found
+// ErrCharNotFound char not found
 var ErrCharNotFound = errors.New("char not found")
 
-//ErrGlyphNotFound font file not contain glyph
+// ErrGlyphNotFound font file not contain glyph
 var ErrGlyphNotFound = errors.New("glyph not found")
 
-//SubsetFontObj pdf subsetFont object
+// SubsetFontObj pdf subsetFont object
 type SubsetFontObj struct {
 	ttfp                  core.TTFParser
 	Family                string
@@ -47,27 +47,27 @@ func (s *SubsetFontObj) write(w io.Writer, objID int) error {
 	return nil
 }
 
-//SetIndexObjCIDFont set IndexObjCIDFont
+// SetIndexObjCIDFont set IndexObjCIDFont
 func (s *SubsetFontObj) SetIndexObjCIDFont(index int) {
 	s.indexObjCIDFont = index
 }
 
-//SetIndexObjUnicodeMap set IndexObjUnicodeMap
+// SetIndexObjUnicodeMap set IndexObjUnicodeMap
 func (s *SubsetFontObj) SetIndexObjUnicodeMap(index int) {
 	s.indexObjUnicodeMap = index
 }
 
-//SetFamily set font family name
+// SetFamily set font family name
 func (s *SubsetFontObj) SetFamily(familyname string) {
 	s.Family = familyname
 }
 
-//GetFamily get font family name
+// GetFamily get font family name
 func (s *SubsetFontObj) GetFamily() string {
 	return s.Family
 }
 
-//SetTtfFontOption set TtfOption must set before SetTTFByPath
+// SetTtfFontOption set TtfOption must set before SetTTFByPath
 func (s *SubsetFontObj) SetTtfFontOption(option TtfOption) {
 	if option.OnGlyphNotFoundSubstitute == nil {
 		option.OnGlyphNotFoundSubstitute = DefaultOnGlyphNotFoundSubstitute
@@ -75,12 +75,12 @@ func (s *SubsetFontObj) SetTtfFontOption(option TtfOption) {
 	s.ttfFontOption = option
 }
 
-//GetTtfFontOption get TtfOption must set before SetTTFByPath
+// GetTtfFontOption get TtfOption must set before SetTTFByPath
 func (s *SubsetFontObj) GetTtfFontOption() TtfOption {
 	return s.ttfFontOption
 }
 
-//KernValueByLeft find kern value from kern table by left
+// KernValueByLeft find kern value from kern table by left
 func (s *SubsetFontObj) KernValueByLeft(left uint) (bool, *core.KernValue) {
 
 	if !s.ttfFontOption.UseKerning {
@@ -99,7 +99,7 @@ func (s *SubsetFontObj) KernValueByLeft(left uint) (bool, *core.KernValue) {
 	return false, nil
 }
 
-//SetTTFByPath set ttf
+// SetTTFByPath set ttf
 func (s *SubsetFontObj) SetTTFByPath(ttfpath string) error {
 	useKerning := s.ttfFontOption.UseKerning
 	s.ttfp.SetUseKerning(useKerning)
@@ -110,7 +110,7 @@ func (s *SubsetFontObj) SetTTFByPath(ttfpath string) error {
 	return nil
 }
 
-//SetTTFByReader set ttf
+// SetTTFByReader set ttf
 func (s *SubsetFontObj) SetTTFByReader(rd io.Reader) error {
 	useKerning := s.ttfFontOption.UseKerning
 	s.ttfp.SetUseKerning(useKerning)
@@ -121,7 +121,7 @@ func (s *SubsetFontObj) SetTTFByReader(rd io.Reader) error {
 	return nil
 }
 
-//SetTTFData set ttf
+// SetTTFData set ttf
 func (s *SubsetFontObj) SetTTFData(data []byte) error {
 	useKerning := s.ttfFontOption.UseKerning
 	s.ttfp.SetUseKerning(useKerning)
@@ -132,7 +132,7 @@ func (s *SubsetFontObj) SetTTFData(data []byte) error {
 	return nil
 }
 
-//AddChars add char to map CharacterToGlyphIndex
+// AddChars add char to map CharacterToGlyphIndex
 func (s *SubsetFontObj) AddChars(txt string) (string, error) {
 	var buff []rune
 	for _, runeValue := range txt {
@@ -193,7 +193,7 @@ func (s *SubsetFontObj) AddChars(txt string) error {
 }
 */
 
-//replaceGlyphThatNotFound find glyph to replaced
+// replaceGlyphThatNotFound find glyph to replaced
 // it returns
 // - true if rune already add to CharacterToGlyphIndex
 // - rune for replace
@@ -214,7 +214,7 @@ func (s *SubsetFontObj) replaceGlyphThatNotFound(runeNotFound rune) (bool, rune,
 	return false, runeNotFound, 0
 }
 
-//CharIndex index of char in glyph table
+// CharIndex index of char in glyph table
 func (s *SubsetFontObj) CharIndex(r rune) (uint, error) {
 	glyIndex, ok := s.CharacterToGlyphIndex.Val(r)
 	if ok {
@@ -223,7 +223,7 @@ func (s *SubsetFontObj) CharIndex(r rune) (uint, error) {
 	return 0, ErrCharNotFound
 }
 
-//CharWidth with of char
+// CharWidth with of char
 func (s *SubsetFontObj) CharWidth(r rune) (uint, error) {
 	glyIndex, ok := s.CharacterToGlyphIndex.Val(r)
 	if ok {

--- a/ttf_option.go
+++ b/ttf_option.go
@@ -1,6 +1,6 @@
 package gopdf
 
-//TtfOption  font option
+// TtfOption  font option
 type TtfOption struct {
 	UseKerning                bool
 	Style                     int               //Regular|Bold|Italic

--- a/unicode_map.go
+++ b/unicode_map.go
@@ -5,7 +5,7 @@ import (
 	"io"
 )
 
-//UnicodeMap unicode map
+// UnicodeMap unicode map
 type UnicodeMap struct {
 	PtrToSubsetFontObj *SubsetFontObj
 	//getRoot            func() *GoPdf
@@ -24,7 +24,7 @@ func (u *UnicodeMap) protection() *PDFProtection {
 	return u.pdfProtection
 }
 
-//SetPtrToSubsetFontObj set pointer to SubsetFontObj
+// SetPtrToSubsetFontObj set pointer to SubsetFontObj
 func (u *UnicodeMap) SetPtrToSubsetFontObj(ptr *SubsetFontObj) {
 	u.PtrToSubsetFontObj = ptr
 }


### PR DESCRIPTION
go 1.19's gofmt improve support for comment. This effect changes to gofmt output.

see: https://go.dev/doc/go1.19#go-doc

In this pr, I run just go fmt.