### PR TITLE
add support for custom line types beyond dashed and dotted

### DIFF
--- a/cache_content_custom_line_type.go
+++ b/cache_content_custom_line_type.go
@@ -1,0 +1,16 @@
+package gopdf
+
+import (
+	"fmt"
+	"io"
+)
+
+type cacheContentCustomLineType struct {
+	dashArray []float64
+	dashPhase float64
+}
+
+func (c *cacheContentCustomLineType) write(w io.Writer, protection *PDFProtection) error {
+	fmt.Fprintf(w, "%0.2f %0.2f d\n", c.dashArray, c.dashPhase)
+	return nil
+}

--- a/content_obj.go
+++ b/content_obj.go
@@ -257,7 +257,14 @@ func (c *ContentObj) AppendStreamSetLineType(t string) {
 	var cache cacheContentLineType
 	cache.lineType = t
 	c.listCache.append(&cache)
+}
 
+// AppendStreamSetCustomLineType : set a custom line type
+func (c *ContentObj) AppendStreamSetCustomLineType(a []float64, p float64) {
+	var cache cacheContentCustomLineType
+	cache.dashArray = a
+	cache.dashPhase = p
+	c.listCache.append(&cache)
 }
 
 // AppendStreamSetGrayFill  set the grayscale fills

--- a/gopdf.go
+++ b/gopdf.go
@@ -170,6 +170,19 @@ func (gp *GoPdf) SetLineType(linetype string) {
 	gp.getContent().AppendStreamSetLineType(linetype)
 }
 
+// SetCustomLineType : set custom line type
+//
+//	Usage:
+//	pdf.SetCustomLineType([]float64{0.8, 0.8}, 0)
+//	pdf.Line(50, 200, 550, 200)
+func (gp *GoPdf) SetCustomLineType(dashArray []float64, dashPhase float64) {
+	for i, _ := range dashArray {
+		gp.UnitsToPointsVar(&dashArray[i])
+	}
+	gp.UnitsToPointsVar(&dashPhase)
+	gp.getContent().AppendStreamSetCustomLineType(dashArray, dashPhase)
+}
+
 // Line : draw line
 //
 //	Usage:


### PR DESCRIPTION
add support for line types with a custom dash array and phase.
Usage:
	pdf.SetCustomLineType([]float64{0.8, 0.8}, 0)
	pdf.Line(50, 200, 550, 200)