### PR TITLE
add support, test, and documentation for header and footer functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,55 @@ func main()  {
 }
 ```
 
+### Header and Footer
+
+```go
+
+package main
+
+import (
+    "log"
+    "github.com/signintech/gopdf"
+)
+
+func main() {
+    pdf := gopdf.GoPdf{}
+    pdf.Start(gopdf.Config{ PageSize: *gopdf.PageSizeA4 }) //595.28, 841.89 = A4
+
+    err = pdf.AddTTFFont("LiberationSerif-Regular", "./test/res/LiberationSerif-Regular.ttf")
+    if err != nil {
+        log.Print(err.Error())
+        return
+    }
+
+    err = pdf.SetFont("LiberationSerif-Regular", "", 14)
+    if err != nil {
+        log.Print(err.Error())
+        return
+    }
+
+    pdf.AddHeader(func() {
+        pdf.SetY(5)
+        pdf.Cell(nil, "header")
+    })
+    pdf.AddFooter(func() {
+        pdf.SetY(825)
+        pdf.Cell(nil, "footer")
+    })
+
+    pdf.AddPage()
+    pdf.SetY(400)
+    pdf.Text("page 1 content")
+    pdf.AddPage()
+    pdf.SetY(400)
+    pdf.Text("page 2 content")
+
+    pdf.WritePdf("header-footer.tmp.pdf")
+
+}
+
+```
+
 ### Draw line
 ```go
 pdf.SetLineWidth(2)

--- a/gopdf.go
+++ b/gopdf.go
@@ -78,6 +78,10 @@ type GoPdf struct {
 	outlines           *OutlinesObj
 	indexOfOutlinesObj int
 
+	//header and footer functions
+	headerFunc func()
+	footerFunc func()
+
 	// gofpdi free pdf document importer
 	fpdi *gofpdi.Importer
 }
@@ -774,6 +778,16 @@ func (gp *GoPdf) AddPageWithOption(opt PageOption) {
 	//reset
 	gp.indexOfContent = -1
 	gp.resetCurrXY()
+
+	if gp.headerFunc != nil {
+		gp.headerFunc()
+		gp.resetCurrXY()
+	}
+
+	if gp.footerFunc != nil {
+		gp.footerFunc()
+		gp.resetCurrXY()
+	}
 }
 
 func (gp *GoPdf) AddOutline(title string) {
@@ -783,6 +797,16 @@ func (gp *GoPdf) AddOutline(title string) {
 // AddOutlineWithPosition add an outline with position
 func (gp *GoPdf) AddOutlineWithPosition(title string) *OutlineObj {
 	return gp.outlines.AddOutlinesWithPosition(gp.curr.IndexOfPageObj+1, title, gp.config.PageSize.H-gp.curr.Y+20)
+}
+
+// AddHeader - add a header function, if present this will be automatically called by AddPage()
+func (gp *GoPdf) AddHeader(f func()) {
+	gp.headerFunc = f
+}
+
+// AddFooter - add a footer function, if present this will be automatically called by AddPage()
+func (gp *GoPdf) AddFooter(f func()) {
+	gp.footerFunc = f
 }
 
 // Start : init gopdf

--- a/gopdf_test.go
+++ b/gopdf_test.go
@@ -732,6 +732,52 @@ func TestTextColor(t *testing.T) {
 	}
 }
 
+func TestAddHeaderFooter(t *testing.T) {
+	err := initTesting()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// create pdf.
+	pdf := GoPdf{}
+	pdf.Start(Config{PageSize: *PageSizeA4})
+
+	err = pdf.AddTTFFont("LiberationSerif-Regular", "./test/res/LiberationSerif-Regular.ttf")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = pdf.SetFont("LiberationSerif-Regular", "", 14)
+	if err != nil {
+		log.Print(err.Error())
+		return
+	}
+
+	pdf.AddHeader(func() {
+		pdf.SetY(5)
+		pdf.Cell(nil, "header")
+	})
+	pdf.AddFooter(func() {
+		pdf.SetY(825)
+		pdf.Cell(nil, "footer")
+	})
+
+	pdf.AddPage()
+	pdf.SetY(400)
+	pdf.Text("page 1 content")
+	pdf.AddPage()
+	pdf.SetY(400)
+	pdf.Text("page 2 content")
+
+	err = pdf.WritePdf("./test/out/header_footer.pdf")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+}
+
 func initTesting() error {
 	err := os.MkdirAll("./test/out", 0777)
 	if err != nil {


### PR DESCRIPTION
Add support for header and footer functions 
Usage:
```go
    pdf.AddHeader(func() {                                                                                                                                                                                                                    
        pdf.SetY(5)                                                                                                                                                                                                                           
        pdf.Cell(nil, "header")                                                                                                                                                                                                               
    })                                                                                                                                                                                                                                        
    pdf.AddFooter(func() {                                                                                                                                                                                                                    
        pdf.SetY(825)                                                                                                                                                                                                                         
        pdf.Cell(nil, "footer")                                                                                                                                                                                                               
    })
```

These functions, if present, are called from AddPage().