### PR TITLE
feat: add support for character spacing

### DIFF
--- a/content_obj.go
+++ b/content_obj.go
@@ -107,6 +107,7 @@ func (c *ContentObj) AppendStreamText(text string) error {
 	fontCountIndex := c.getRoot().curr.FontFontCount + 1
 	fontSize := c.getRoot().curr.FontSize
 	fontStyle := c.getRoot().curr.FontStyle
+	charSpacing := c.getRoot().curr.CharSpacing
 	x := c.getRoot().curr.X
 	y := c.getRoot().curr.Y
 	setXCount := c.getRoot().curr.setXCount
@@ -122,6 +123,7 @@ func (c *ContentObj) AppendStreamText(text string) error {
 		fontCountIndex: fontCountIndex,
 		fontSize:       fontSize,
 		fontStyle:      fontStyle,
+		charSpacing:    charSpacing,
 		setXCount:      setXCount,
 		x:              x,
 		y:              y,
@@ -149,6 +151,7 @@ func (c *ContentObj) AppendStreamSubsetFont(rectangle *Rect, text string, cellOp
 	fontCountIndex := c.getRoot().curr.FontFontCount + 1
 	fontSize := c.getRoot().curr.FontSize
 	fontStyle := c.getRoot().curr.FontStyle
+	charSpacing := c.getRoot().curr.CharSpacing
 	x := c.getRoot().curr.X
 	y := c.getRoot().curr.Y
 	setXCount := c.getRoot().curr.setXCount
@@ -162,6 +165,7 @@ func (c *ContentObj) AppendStreamSubsetFont(rectangle *Rect, text string, cellOp
 		fontCountIndex: fontCountIndex,
 		fontSize:       fontSize,
 		fontStyle:      fontStyle,
+		charSpacing:    charSpacing,
 		setXCount:      setXCount,
 		x:              x,
 		y:              y,

--- a/current.go
+++ b/current.go
@@ -16,6 +16,8 @@ type Current struct {
 	FontFontCount int
 	FontType      int // CURRENT_FONT_TYPE_IFONT or  CURRENT_FONT_TYPE_SUBSET
 
+	CharSpacing float64
+
 	FontISubset *SubsetFontObj // FontType == CURRENT_FONT_TYPE_SUBSET
 
 	//page

--- a/gopdf.go
+++ b/gopdf.go
@@ -940,6 +940,12 @@ func (gp *GoPdf) SetFontSize(fontSize float64) error {
 	return nil
 }
 
+// SetCharSpacing : set the character spacing of the currently active font
+func (gp *GoPdf) SetCharSpacing(charSpacingInPt float64) error {
+	gp.curr.CharSpacing = charSpacingInPt
+	return nil
+}
+
 // WritePdf : write pdf file
 func (gp *GoPdf) WritePdf(pdfPath string) error {
 	return ioutil.WriteFile(pdfPath, gp.GetBytesPdf(), 0644)
@@ -1098,7 +1104,7 @@ func (gp *GoPdf) MultiCell(rectangle *Rect, text string) error {
 	if err != nil {
 		return err
 	}
-	_, lineHeight, _, err := createContent(gp.curr.FontISubset, text, gp.curr.FontSize, nil)
+	_, lineHeight, _, err := createContent(gp.curr.FontISubset, text, gp.curr.FontSize, gp.curr.CharSpacing, nil)
 	if err != nil {
 		return err
 	}
@@ -1141,7 +1147,7 @@ func (gp *GoPdf) IsFitMultiCell(rectangle *Rect, text string) (bool, float64, er
 	if err != nil {
 		return false, totalLineHeight, err
 	}
-	_, lineHeight, _, err := createContent(gp.curr.FontISubset, text, gp.curr.FontSize, nil)
+	_, lineHeight, _, err := createContent(gp.curr.FontISubset, text, gp.curr.FontSize, gp.curr.CharSpacing, nil)
 
 	if err != nil {
 		return false, totalLineHeight, err
@@ -1212,7 +1218,7 @@ func (gp *GoPdf) MultiCellWithOption(rectangle *Rect, text string, opt CellOptio
 	if err != nil {
 		return err
 	}
-	_, lineHeight, _, err := createContent(gp.curr.FontISubset, text, gp.curr.FontSize, nil)
+	_, lineHeight, _, err := createContent(gp.curr.FontISubset, text, gp.curr.FontSize, gp.curr.CharSpacing, nil)
 	if err != nil {
 		return err
 	}
@@ -1666,7 +1672,7 @@ func (gp *GoPdf) MeasureTextWidth(text string) (float64, error) {
 		return 0, err
 	}
 
-	_, _, textWidthPdfUnit, err := createContent(gp.curr.FontISubset, text, gp.curr.FontSize, nil)
+	_, _, textWidthPdfUnit, err := createContent(gp.curr.FontISubset, text, gp.curr.FontSize, gp.curr.CharSpacing, nil)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
This allows setting the (inter-)character spacing for the current font using `pdf.SetCharSpacing(charSpacingInPt)`.

I tried to implement this as complete as possible and it works for my use case, but I am missing the detailed insight into this library to judge whether there is something missing. Feedback very much appreciated!