### PR TITLE
Fix go vet failure

### DIFF
--- a/fontmaker/core/fontmaker.go
+++ b/fontmaker/core/fontmaker.go
@@ -329,7 +329,7 @@ func (f *FontMaker) MakeWidthArray(widths map[int]int) (string, error) {
 	str := "\tme.cw = make(gopdf.FontCw)\n"
 	for c := 0; c <= 255; c++ {
 		str += "\tme.cw["
-		chr := string(c)
+		chr := string(rune(c))
 		if chr == "\"" {
 			str += "gopdf.ToByte(\"\\\"\")"
 		} else if chr == "\\" {


### PR DESCRIPTION
When running the go vet linter on the entire project, we encounter a failure stating that an integer to string conversion using "string(c)" can lead to unexpected results. Such a failure might become an error in future versions of Go. See for example https://go.dev/doc/go1.15#vet.

By explicitly converting the integer to a rune before casting it to a string, we avoid this issue and can run go test without the "-vet=off" flag.