### PR TITLE
Remove unnecessary returns

### DIFF
--- a/gopdf.go
+++ b/gopdf.go
@@ -196,7 +196,7 @@ func (gp *GoPdf) SetLineType(linetype string) {
 //	pdf.SetCustomLineType([]float64{0.8, 0.8}, 0)
 //	pdf.Line(50, 200, 550, 200)
 func (gp *GoPdf) SetCustomLineType(dashArray []float64, dashPhase float64) {
-	for i, _ := range dashArray {
+	for i := range dashArray {
 		gp.UnitsToPointsVar(&dashArray[i])
 	}
 	gp.UnitsToPointsVar(&dashPhase)

--- a/page_option.go
+++ b/page_option.go
@@ -7,10 +7,7 @@ type PageOption struct {
 }
 
 func (p PageOption) isEmpty() bool {
-	if p.PageSize == nil {
-		return true
-	}
-	return false
+	return p.PageSize == nil
 }
 
 func (p PageOption) isTrimBoxSet() bool {


### PR DESCRIPTION
- Applied concise return for `isEmpty()`.
- Simplified range for `SetCustomLineType()`.