### PR TITLE
fix: use page size constant as standard for A4

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ import (
 
 func main()  {
 	pdf := gopdf.GoPdf{}
-	pdf.Start(gopdf.Config{ PageSize: *gopdf.PageSizeA4 }) //595.28, 841.89 = A4
+	pdf.Start(gopdf.Config{ PageSize: *gopdf.PageSizeA4 })
 	pdf.AddPage()
 	err := pdf.AddTTFFont("times", "./test/res/times.ttf")
 	if err != nil {
@@ -158,7 +158,7 @@ import (
 
 func main() {
     pdf := gopdf.GoPdf{}
-    pdf.Start(gopdf.Config{ PageSize: *gopdf.PageSizeA4 }) //595.28, 841.89 = A4
+    pdf.Start(gopdf.Config{ PageSize: *gopdf.PageSizeA4 })
 
     err := pdf.AddTTFFont("LiberationSerif-Regular", "./test/res/LiberationSerif-Regular.ttf")
     if err != nil {
@@ -282,7 +282,7 @@ func main() {
 
 	pdf := gopdf.GoPdf{}
 	pdf.Start(gopdf.Config{
-		PageSize: *gopdf.PageSizeA4, //595.28, 841.89 = A4
+		PageSize: *gopdf.PageSizeA4,
 		Protection: gopdf.PDFProtectionConfig{
 			UseProtection: true,
 			Permissions: gopdf.PermissionsPrint | gopdf.PermissionsCopy | gopdf.PermissionsModify,
@@ -328,7 +328,7 @@ func main() {
         }
 
         pdf := gopdf.GoPdf{}
-        pdf.Start(gopdf.Config{PageSize: gopdf.Rect{W: 595.28, H: 841.89}}) //595.28, 841.89 = A4
+        pdf.Start(gopdf.Config{PageSize: *gopdf.PageSizeA4})
 
         pdf.AddPage()
 
@@ -403,14 +403,14 @@ func main() {
 
     // Base trim-box
     pdf.Start(gopdf.Config{
-        PageSize: *gopdf.PageSizeA4, //595.28, 841.89 = A4
-        TrimBox: gopdf.Box{Left: mm6ToPx, Top: mm6ToPx, Right: 595 - mm6ToPx, Bottom: 842 - mm6ToPx},
+        PageSize: *gopdf.PageSizeA4,
+        TrimBox: gopdf.Box{Left: mm6ToPx, Top: mm6ToPx, Right: gopdf.PageSizeA4.W - mm6ToPx, Bottom: gopdf.PageSizeA4.H - mm6ToPx},
     })
 
     // Page trim-box
     opt := gopdf.PageOption{
-        PageSize: gopdf.PageSizeA4, //595.28, 841.89 = A4
-        TrimBox: &gopdf.Box{Left: mm6ToPx, Top: mm6ToPx, Right: 595 - mm6ToPx, Bottom: 842 - mm6ToPx},
+        PageSize: *gopdf.PageSizeA4,
+        TrimBox: &gopdf.Box{Left: mm6ToPx, Top: mm6ToPx, Right: gopdf.PageSizeA4.W - mm6ToPx, Bottom: gopdf.PageSizeA4.H - mm6ToPx},
     }
     pdf.AddPageWithOption(opt)
 
@@ -448,7 +448,7 @@ You can use **func PlaceHolderText** to create the point where you want "total n
 ```go
 func main(){
     	pdf := GoPdf{}
-	pdf.Start(Config{PageSize: Rect{W: 595.28, H: 841.89}}) 
+	pdf.Start(Config{PageSize: *PageSizeA4}) 
 	pdf.AddTTFFont("LiberationSerif-Regular", "LiberationSerif-Regular.ttf")
 	pdf.SetFont("LiberationSerif-Regular", "", 14) }
 

--- a/config.go
+++ b/config.go
@@ -17,7 +17,7 @@ const (
 	//We use a dpi of 96 dpi as the default, so we get a conversionUnitPX = 3.0 / 4.0, which comes from 72.0 / 96.0.
 	//If you want to change this value, you can change it at Config.ConversionForUnit
 	//example: If you use dpi at 300.0
-	//pdf.Start(gopdf.Config{PageSize: gopdf.Rect{W: 595.28, H: 841.89}, ConversionForUnit: 72.0 / 300.0 })
+	//pdf.Start(gopdf.Config{PageSize: *gopdf.PageSizeA4, ConversionForUnit: 72.0 / 300.0 })
 	conversionUnitPX = 3.0 / 4.0
 )
 

--- a/examples/mask-image/example.go
+++ b/examples/mask-image/example.go
@@ -21,7 +21,7 @@ func init() {
 func main() {
 	pdf := gopdf.GoPdf{}
 
-	pdf.Start(gopdf.Config{PageSize: gopdf.Rect{W: 595.28, H: 841.89}}) //595.28, 841.89 = A4
+	pdf.Start(gopdf.Config{PageSize: *gopdf.PageSizeA4})
 	pdf.AddPage()
 
 	if err := pdf.AddTTFFont("loma", resourcesPath+"/LiberationSerif-Regular.ttf"); err != nil {

--- a/examples/mask-with-rotated-image/example.go
+++ b/examples/mask-with-rotated-image/example.go
@@ -21,7 +21,7 @@ func init() {
 func main() {
 	pdf := gopdf.GoPdf{}
 
-	pdf.Start(gopdf.Config{PageSize: gopdf.Rect{W: 595.28, H: 841.89}}) //595.28, 841.89 = A4
+	pdf.Start(gopdf.Config{PageSize: *gopdf.PageSizeA4})
 	pdf.AddPage()
 
 	if err := pdf.AddTTFFont("loma", resourcesPath+"/LiberationSerif-Regular.ttf"); err != nil {

--- a/fontsizefloat64_test.go
+++ b/fontsizefloat64_test.go
@@ -26,7 +26,7 @@ func TestSetFontCheckGetX(t *testing.T) {
 	prefix := "Afont"
 	font := "test/res/LiberationSerif-Regular.ttf"
 	pdf := GoPdf{}
-	pdf.Start(Config{Unit: UnitPT, PageSize: Rect{W: 595.28, H: 841.89}})
+	pdf.Start(Config{Unit: UnitPT, PageSize: *PageSizeA4})
 	pdf.AddPage()
 	if err := pdf.AddTTFFontWithOption(prefix, font, TtfOption{UseKerning: true}); err != nil {
 		t.Error(err)
@@ -59,7 +59,7 @@ func setup(t *testing.T) (string, *GoPdf, float64, float64) {
 	prefix := "Afont"
 	font := "test/res/LiberationSerif-Regular.ttf"
 	pdf := GoPdf{}
-	pdf.Start(Config{Unit: UnitPT, PageSize: Rect{W: 595.28, H: 841.89}})
+	pdf.Start(Config{Unit: UnitPT, PageSize: *PageSizeA4})
 	pdf.AddPage()
 	if err := pdf.AddTTFFontWithOption(prefix, font, TtfOption{UseKerning: true}); err != nil {
 		t.Error(err)

--- a/gopdf_test.go
+++ b/gopdf_test.go
@@ -18,7 +18,7 @@ func BenchmarkPdfWithImageHolder(b *testing.B) {
 	}
 
 	pdf := GoPdf{}
-	pdf.Start(Config{PageSize: Rect{W: 595.28, H: 841.89}}) //595.28, 841.89 = A4
+	pdf.Start(Config{PageSize: *PageSizeA4})
 	pdf.AddPage()
 	err = pdf.AddTTFFont("LiberationSerif-Regular", "./test/res/LiberationSerif-Regular.ttf")
 	if err != nil {
@@ -218,7 +218,7 @@ func BenchmarkAddTTFFontByReader(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		pdf := &GoPdf{}
-		pdf.Start(Config{PageSize: Rect{W: 595.28, H: 841.89}}) //595.28, 841.89 = A4
+		pdf.Start(Config{PageSize: *PageSizeA4})
 		if err := pdf.AddTTFFontByReader("LiberationSerif-Regular", bytes.NewReader(fontData)); err != nil {
 			return
 		}
@@ -261,7 +261,7 @@ func BenchmarkAddTTFFontData(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		pdf := &GoPdf{}
-		pdf.Start(Config{PageSize: Rect{W: 595.28, H: 841.89}}) //595.28, 841.89 = A4
+		pdf.Start(Config{PageSize: *PageSizeA4})
 		if err := pdf.AddTTFFontData("LiberationSerif-Regular", fontData); err != nil {
 			return
 		}
@@ -325,7 +325,7 @@ func writeFile(name string, data []byte, perm os.FileMode) error {
 }
 
 func generatePDFBytesByAddTTFFontData(pdf *GoPdf, fontData []byte) ([]byte, error) {
-	pdf.Start(Config{PageSize: Rect{W: 595.28, H: 841.89}}) //595.28, 841.89 = A4
+	pdf.Start(Config{PageSize: *PageSizeA4})
 	if pdf.GetNumberOfPages() != 0 {
 		return nil, errors.New("Invalid starting number of pages, should be 0")
 	}
@@ -525,11 +525,11 @@ func TestClearValue(t *testing.T) {
 	}
 
 	pdf := GoPdf{}
-	pdf.Start(Config{PageSize: Rect{W: 595.28, H: 841.89}, Protection: PDFProtectionConfig{
+	pdf.Start(Config{PageSize: *PageSizeA4, Protection: PDFProtectionConfig{
 		UseProtection: true,
 		OwnerPass:     []byte("123456"),
 		UserPass:      []byte("123456"),
-	}}) //595.28, 841.89 = A4
+	}})
 	pdf.AddPage()
 	err = pdf.AddTTFFont("LiberationSerif-Regular", "./test/res/LiberationSerif-Regular.ttf")
 	if err != nil {
@@ -569,10 +569,10 @@ func TestClearValue(t *testing.T) {
 	pdf.WritePdf("./test/out/test_clear_value.pdf")
 
 	//reset
-	pdf.Start(Config{PageSize: Rect{W: 595.28, H: 841.89}}) //595.28, 841.89 = A4
+	pdf.Start(Config{PageSize: *PageSizeA4})
 
 	pdf2 := GoPdf{}
-	pdf2.Start(Config{PageSize: Rect{W: 595.28, H: 841.89}}) //595.28, 841.89 = A4
+	pdf2.Start(Config{PageSize: *PageSizeA4})
 
 	//check
 	if pdf.margins != pdf2.margins {
@@ -790,7 +790,7 @@ func initTesting() error {
 // further processing. Tests will fail in case adding or setting the font fails.
 func setupDefaultA4PDF(t *testing.T) *GoPdf {
 	pdf := GoPdf{}
-	pdf.Start(Config{PageSize: Rect{W: 595.28, H: 841.89}}) //595.28, 841.89 = A4
+	pdf.Start(Config{PageSize: *PageSizeA4})
 	err := pdf.AddTTFFont("LiberationSerif-Regular", "./test/res/LiberationSerif-Regular.ttf")
 	if err != nil {
 		t.Fatal(err)

--- a/kern_test.go
+++ b/kern_test.go
@@ -33,7 +33,7 @@ func TestKern01(t *testing.T) {
 
 func kern01(font string, prefix string, leftRune rune, rightRune rune) (int, error) {
 	pdf := GoPdf{}
-	pdf.Start(Config{Unit: UnitPT, PageSize: Rect{W: 595.28, H: 841.89}}) //595.28, 841.89 = A4
+	pdf.Start(Config{Unit: UnitPT, PageSize: *PageSizeA4})
 	pdf.AddPage()
 	err := pdf.AddTTFFontWithOption(prefix, font, TtfOption{
 		UseKerning: true,

--- a/placeholder_test.go
+++ b/placeholder_test.go
@@ -14,7 +14,7 @@ func TestPlaceHolderText(t *testing.T) {
 	}
 
 	pdf := GoPdf{}
-	pdf.Start(Config{PageSize: Rect{W: 595.28, H: 841.89}}) //595.28, 841.89 = A4
+	pdf.Start(Config{PageSize: *PageSizeA4})
 	err = pdf.AddTTFFont("LiberationSerif-Regular", "./test/res/LiberationSerif-Regular.ttf")
 	if err != nil {
 		t.Error(err)
@@ -67,7 +67,7 @@ func TestPlaceHolderText2(t *testing.T) {
 	}
 
 	pdf := GoPdf{}
-	pdf.Start(Config{PageSize: Rect{W: 595.28, H: 841.89}}) //595.28, 841.89 = A4
+	pdf.Start(Config{PageSize: *PageSizeA4})
 	err = pdf.AddTTFFont("LiberationSerif-Regular", "./test/res/LiberationSerif-Regular.ttf")
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
Resolves Question about A4 paper size https://github.com/signintech/gopdf/issues/129

This follows the sizes outline in https://communities.efi.com/s/article/International-standard-paper-sizes-in-PostScript-and-PDF?language=en_US and replaces uses of the floating point example with the nearest integer variable constant in `page_sizes.go`.