### PR TITLE
fix can't split text by '\n' in MultiCellWithOption

### DIFF
--- a/gopdf.go
+++ b/gopdf.go
@@ -1208,11 +1208,11 @@ func (gp *GoPdf) MultiCellWithOption(rectangle *Rect, text string, opt CellOptio
 	length := len([]rune(text))
 
 	// get lineHeight
-	text, err = gp.curr.FontISubset.AddChars(text)
+	itext, err := gp.curr.FontISubset.AddChars(text)
 	if err != nil {
 		return err
 	}
-	_, lineHeight, _, err := createContent(gp.curr.FontISubset, text, gp.curr.FontSize, nil)
+	_, lineHeight, _, err := createContent(gp.curr.FontISubset, itext, gp.curr.FontSize, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
in function MultiCellWithOption,
```
 text, err = gp.curr.FontISubset.AddChars(text)
```
This will replace '\n' with ' ' (space), which means it cannot be split by '\n'.

Change the variable `text` to `itext` to get the line height, so that `text` also includes '\n', allowing for proper splitting.