### PR TITLE
refactor: reduce memory allocations in AddChars()

### DIFF
--- a/subset_font_obj.go
+++ b/subset_font_obj.go
@@ -25,6 +25,7 @@ type SubsetFontObj struct {
 	ttfFontOption         TtfOption
 	funcKernOverride      FuncKernOverride
 	funcGetRoot           func() *GoPdf
+	addCharsBuff          []rune
 }
 
 func (s *SubsetFontObj) init(funcGetRoot func() *GoPdf) {
@@ -134,10 +135,10 @@ func (s *SubsetFontObj) SetTTFData(data []byte) error {
 
 // AddChars add char to map CharacterToGlyphIndex
 func (s *SubsetFontObj) AddChars(txt string) (string, error) {
-	var buff []rune
+	s.addCharsBuff = s.addCharsBuff[:0]
 	for _, runeValue := range txt {
 		if s.CharacterToGlyphIndex.KeyExists(runeValue) {
-			buff = append(buff, runeValue)
+			s.addCharsBuff = append(s.addCharsBuff, runeValue)
 			continue
 		}
 		glyphIndex, err := s.CharCodeToGlyphIndex(runeValue)
@@ -152,15 +153,15 @@ func (s *SubsetFontObj) AddChars(txt string) (string, error) {
 				s.CharacterToGlyphIndex.Set(runeValueReplace, glyphIndexReplace) // [runeValue] = glyphIndex
 			}
 			//end: try to find rune for replace
-			buff = append(buff, runeValueReplace)
+			s.addCharsBuff = append(s.addCharsBuff, runeValueReplace)
 			continue
 		} else if err != nil {
 			return "", err
 		}
 		s.CharacterToGlyphIndex.Set(runeValue, glyphIndex) // [runeValue] = glyphIndex
-		buff = append(buff, runeValue)
+		s.addCharsBuff = append(s.addCharsBuff, runeValue)
 	}
-	return string(buff), nil
+	return string(s.addCharsBuff), nil
 }
 
 /*


### PR DESCRIPTION
Hi. This simple PR should help to reduce memory allocations in AddChars()  function.

My test case:

before
```
BenchmarkGenerateDocument-16    30    38637542 ns/op    23502649 B/op    320497 allocs/op
```

after
```
BenchmarkGenerateDocument-16    31    34976746 ns/op    18924331 B/op    205436 allocs/op
```