### PR TITLE
fix: Solve the problem of overflow of line content when table align is center

### DIFF
--- a/gopdf.go
+++ b/gopdf.go
@@ -1294,8 +1294,17 @@ func (gp *GoPdf) MultiCellWithOption(rectangle *Rect, text string, opt CellOptio
 		return err
 	}
 
+	startHeight := rectangle.H
+	if l := len(textSplits); l > 1 {
+		shiftLines := l / 2
+		if l%2 != 0 {
+			shiftLines += 1
+		}
+		startHeight = rectangle.H - (lineHeight+1.5)*float64(shiftLines)
+	}
+
 	for _, text := range textSplits {
-		gp.CellWithOption(&Rect{W: rectangle.W, H: rectangle.H}, string(text), opt)
+		gp.CellWithOption(&Rect{W: rectangle.W, H: startHeight}, string(text), opt)
 		gp.Br(lineHeight)
 		gp.SetX(x)
 	}


### PR DESCRIPTION
#314 Sorry, this only solves the problem of content exceeding the limit, but does not really achieve vertical centering.
The original effect：
![1](https://github.com/user-attachments/assets/56d8bf85-065c-42d8-8910-91386736bd00)
Current effect:
![2](https://github.com/user-attachments/assets/19237c8f-1f91-478e-aa78-50e7c3f5cd10)

