### PR TITLE
fix(config): correct points to units conversion

### DIFF
--- a/config.go
+++ b/config.go
@@ -92,7 +92,7 @@ func PointsToUnits(t int, u float64) float64 {
 
 func pointsToUnits(unitCfg unitConfigurator, u float64) float64 {
 	if unitCfg.getConversionForUnit() != 0 {
-		return u * unitCfg.getConversionForUnit()
+		return u / unitCfg.getConversionForUnit()
 	}
 	switch unitCfg.getUnit() {
 	case UnitPT:


### PR DESCRIPTION
- Change multiplication to division for unit conversion
- This fixes the incorrect conversion logic in the PointsToUnits function