### PR TITLE
feat: expose page size from fpdi either from a readseeker or from a file

### DIFF
--- a/gopdf.go
+++ b/gopdf.go
@@ -1575,6 +1575,20 @@ func (gp *GoPdf) ImportPageStream(sourceStream *io.ReadSeeker, pageno int, box s
 	return tpl
 }
 
+// GetStreamPageSizes gets the sizes of the pages using a stream
+// Returns a map of available pages and its box sizes starting with the first page at index 1 containing a map of boxes containing a map of size values
+func (gp *GoPdf) GetStreamPageSizes(sourceStream *io.ReadSeeker) map[int]map[string]map[string]float64 {
+        gp.fpdi.SetSourceStream(sourceStream)
+        return gp.fpdi.GetPageSizes()
+}
+
+// GetPageSizes gets the sizes of the pages of a pdf file1
+// Returns a map of available pages and its box sizes starting with the first page at index 1 containing a map of boxes containing a map of size values
+func (gp *GoPdf) GetPageSizes(sourceFile string) map[int]map[string]map[string]float64 {
+        gp.fpdi.SetSourceFile(sourceFile)
+        return gp.fpdi.GetPageSizes()
+}
+
 // UseImportedTemplate draws an imported PDF page.
 func (gp *GoPdf) UseImportedTemplate(tplid int, x float64, y float64, w float64, h float64) {
 	gp.UnitsToPointsVar(&x, &y, &w, &h)


### PR DESCRIPTION
This PR introduces two new functions: pdf.GetStreamPageSizes and pdf.GetPageSizes. They are used to expose the fpdi.GetPageSizes() function so one can get page sizes from existing pdf documents. 

Let me know if you want any changes to this functions