### PR TITLE
Add ColorSpace implementation for cut contour purposes

### DIFF
--- a/cache_color_space.go
+++ b/cache_color_space.go
@@ -1,0 +1,15 @@
+package gopdf
+
+import (
+	"fmt"
+	"io"
+)
+
+type cacheColorSpace struct {
+	countOfSpaceColor int
+}
+
+func (c *cacheColorSpace) write(w io.Writer, protection *PDFProtection) error {
+	fmt.Fprintf(w, "/CS%d CS 1.0000 SCN\n", c.countOfSpaceColor+1)
+	return nil
+}

--- a/color_space_obj.go
+++ b/color_space_obj.go
@@ -1,0 +1,47 @@
+package gopdf
+
+import (
+	"fmt"
+	"io"
+)
+
+type ColorSpaceObj struct {
+	CountOfSpaceColor int
+	Name              string
+	Contour           bool
+	r                 float64
+	g                 float64
+	b                 float64
+}
+
+func (c *ColorSpaceObj) init(func() *GoPdf) {}
+
+func (c *ColorSpaceObj) getType() string {
+	return "ColorSpace"
+}
+
+func (c *ColorSpaceObj) write(w io.Writer, objID int) error {
+
+	if c.Contour {
+		io.WriteString(w, "[ /Separation /CutContour /DeviceRGB\n")
+	} else {
+		io.WriteString(w, "[ /Separation /DeviceRGB\n")
+	}
+
+	io.WriteString(w, "		<< \n")
+	io.WriteString(w, "			/FunctionType 2\n")
+	io.WriteString(w, "			/Domain [0 1]\n")
+	io.WriteString(w, "			/C0 [0.0 0.0 0.0]\n")
+	fmt.Fprintf(w, "			/C1 [%.3f %.3f %.3f]\n", c.r, c.g, c.b)
+	io.WriteString(w, "			/N 1\n")
+	io.WriteString(w, "		>>\n")
+	io.WriteString(w, "]\n")
+
+	return nil
+}
+
+func (c *ColorSpaceObj) SetColor(r, g, b uint8) {
+	c.r = float64(r) / 255.0
+	c.g = float64(g) / 255.0
+	c.b = float64(b) / 255.0
+}

--- a/color_space_obj.go
+++ b/color_space_obj.go
@@ -8,31 +8,26 @@ import (
 type ColorSpaceObj struct {
 	CountOfSpaceColor int
 	Name              string
-	Contour           bool
-	r                 float64
-	g                 float64
-	b                 float64
+	spaceName         string
+	colorString0      string
+	colorString1      string
+	space             string
 }
 
-func (c *ColorSpaceObj) init(func() *GoPdf) {}
+func (cs *ColorSpaceObj) init(func() *GoPdf) {}
 
-func (c *ColorSpaceObj) getType() string {
+func (cs *ColorSpaceObj) getType() string {
 	return "ColorSpace"
 }
 
-func (c *ColorSpaceObj) write(w io.Writer, objID int) error {
+func (cs *ColorSpaceObj) write(w io.Writer, objID int) error {
 
-	if c.Contour {
-		io.WriteString(w, "[ /Separation /CutContour /DeviceRGB\n")
-	} else {
-		io.WriteString(w, "[ /Separation /DeviceRGB\n")
-	}
-
+	fmt.Fprintf(w, "[ /Separation %s %s\n", cs.spaceName, cs.space)
 	io.WriteString(w, "		<< \n")
 	io.WriteString(w, "			/FunctionType 2\n")
 	io.WriteString(w, "			/Domain [0 1]\n")
-	io.WriteString(w, "			/C0 [0.0 0.0 0.0]\n")
-	fmt.Fprintf(w, "			/C1 [%.3f %.3f %.3f]\n", c.r, c.g, c.b)
+	fmt.Fprintf(w, "			/C0 [%s]\n", cs.colorString0)
+	fmt.Fprintf(w, "			/C1 [%s]\n", cs.colorString1)
 	io.WriteString(w, "			/N 1\n")
 	io.WriteString(w, "		>>\n")
 	io.WriteString(w, "]\n")
@@ -40,8 +35,16 @@ func (c *ColorSpaceObj) write(w io.Writer, objID int) error {
 	return nil
 }
 
-func (c *ColorSpaceObj) SetColor(r, g, b uint8) {
-	c.r = float64(r) / 255.0
-	c.g = float64(g) / 255.0
-	c.b = float64(b) / 255.0
+func (cs *ColorSpaceObj) SetColorRBG(r, g, b uint8) {
+	cs.colorString0 = "0.0 0.0 0.0"
+	cs.colorString1 = fmt.Sprintf("%.3f %.3f %.3f", float64(r)/255.0, float64(g)/255.0, float64(b)/255.0)
+	cs.space = "/DeviceRGB"
+	cs.spaceName = fmt.Sprintf("/%s", cs.Name)
+}
+
+func (cs *ColorSpaceObj) SetColorCMYK(c, m, y, k uint8) {
+	cs.colorString0 = "0.0 0.0 0.0 0.0"
+	cs.colorString1 = fmt.Sprintf("%.3f %.3f %.3f %.3f", float64(c)/100.0, float64(m)/100.0, float64(y)/100.0, float64(k)/100.0)
+	cs.space = "/DeviceCMYK"
+	cs.spaceName = fmt.Sprintf("/%s", cs.Name)
 }

--- a/content_obj.go
+++ b/content_obj.go
@@ -438,6 +438,12 @@ func (c *ContentObj) appendRotateReset() {
 	c.listCache.append(&cache)
 }
 
+func (c *ContentObj) appendColorSpace(countOfSpaceColor int) {
+	var cache cacheColorSpace
+	cache.countOfSpaceColor = countOfSpaceColor
+	c.listCache.append(&cache)
+}
+
 // ContentObjCalTextHeight : calculates height of text.
 func ContentObjCalTextHeight(fontsize int) float64 {
 	return ContentObjCalTextHeightPrecise(float64(fontsize))

--- a/current.go
+++ b/current.go
@@ -16,6 +16,9 @@ type Current struct {
 	FontFontCount int
 	FontType      int // CURRENT_FONT_TYPE_IFONT or  CURRENT_FONT_TYPE_SUBSET
 
+	IndexOfColorSpaceObj int
+	CountOfColorSpace    int
+
 	CharSpacing float64
 
 	FontISubset *SubsetFontObj // FontType == CURRENT_FONT_TYPE_SUBSET

--- a/procset_obj.go
+++ b/procset_obj.go
@@ -9,6 +9,7 @@ import (
 type ProcSetObj struct {
 	//Font
 	Relates             RelateFonts
+	RelateColorSpaces   RelateColorSpaces
 	RelateXobjs         RelateXobjects
 	ExtGStates          []ExtGS
 	ImportedTemplateIds map[string]int
@@ -32,6 +33,14 @@ func (pr *ProcSetObj) write(w io.Writer, objID int) error {
 	fonts += "\t>>\n"
 
 	content += fonts
+
+	colorSpaces := "\t/ColorSpace <<\n"
+	for _, relate := range pr.RelateColorSpaces {
+		colorSpaces += fmt.Sprintf("\t\t/CS%d %d 0 R\n", relate.CountOfColorSpace+1, relate.IndexOfObj+1)
+	}
+	colorSpaces += "\t>>\n"
+
+	content += colorSpaces
 
 	xobjects := "\t/XObject <<\n"
 	for _, XObject := range pr.RelateXobjs {
@@ -97,6 +106,16 @@ type RelateFont struct {
 	//etc  5 0 R
 	IndexOfObj int
 	Style      int // Regular|Bold|Italic
+}
+
+type RelateColorSpaces []RelateColorSpace
+
+type RelateColorSpace struct {
+	Name string
+	//etc /CS1
+	CountOfColorSpace int
+	//etc  5 0 R
+	IndexOfObj int
 }
 
 // RelateXobjects is a slice of RelateXobject.


### PR DESCRIPTION
add new ColorSpace in RGB, with name CutContour because plotter machine use as for cut

`AddColorSpaceRGB("CutContour", 0, 255, 0)`

same in CMYK

`AddColorSpaceCMYK("CutContour", 0, 100, 0, 0)`

than use set function to apply it

`SetColorSpace("CutContour")` 