### PR TITLE
fix:prevent text transparency from leaking to later content

### DIFF
--- a/cache_content_text.go
+++ b/cache_content_text.go
@@ -143,6 +143,13 @@ func (c *cacheContentText) write(w io.Writer, protection *PDFProtection) error {
 		return err
 	}
 
+	hasTransparency := len(c.cellOpt.extGStateIndexes) > 0
+	if hasTransparency {
+		if _, err := io.WriteString(w, "q\n"); err != nil {
+			return err
+		}
+	}
+
 	for _, extGStateIndex := range c.cellOpt.extGStateIndexes {
 		linkToGSObj := fmt.Sprintf("/GS%d gs\n", extGStateIndex)
 		if _, err := io.WriteString(w, linkToGSObj); err != nil {
@@ -198,6 +205,12 @@ func (c *cacheContentText) write(w io.Writer, protection *PDFProtection) error {
 	}
 
 	c.drawBorder(w)
+
+	if hasTransparency {
+		if _, err := io.WriteString(w, "Q\n"); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
CellWithOption applies text transparency without wrapping the ExtGState change in q/Q graphics state save/restore
  operators. The generated content stream emits `/GSx gs` before `BT ... ET`, but never restores the previous graphics
  state afterward. Since PDF transparency is part of the graphics state, the alpha setting leaks into subsequent drawing
  operations, causing later Text output to render with the same reduced opacity.