### PR TITLE
Add Justify text alignment for Cell and MultiCell

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A minimum version of Go 1.13 is required.
   - Set image mask
 - Password protection
 - Font [kerning](https://en.wikipedia.org/wiki/Kerning)
+- Text alignment (left, center, right, justify)
 
 ## Installation
 
@@ -54,6 +55,24 @@ func main() {
 
 }
 
+```
+
+### Justified text
+
+Use `Justify` in `CellOption.Align` to stretch text to the full cell width.
+It works for a single line (`CellWithOption`) and for wrapped paragraphs
+(`MultiCellWithOption`). In a paragraph, every line is justified except the
+last line, which stays left-aligned. A line with no spaces, or one that already
+fills (or overflows) the cell, is left-aligned unchanged.
+
+```go
+// Single justified line
+pdf.CellWithOption(&gopdf.Rect{W: 400, H: 20}, text,
+    gopdf.CellOption{Align: gopdf.Justify | gopdf.Top})
+
+// Justified paragraph (last line left-aligned automatically)
+pdf.MultiCellWithOption(&gopdf.Rect{W: 400, H: 200}, paragraph,
+    gopdf.CellOption{Align: gopdf.Justify})
 ```
 
 ### Set text color using RGB color model

--- a/cache_content_text.go
+++ b/cache_content_text.go
@@ -80,6 +80,20 @@ func convertTypoUnit(val float64, unitsPerEm uint, fontSize float64) float64 {
 	return val * fontSize / 1000.0
 }
 
+// justifyAdjustment returns the TJ-array number to emit after each interior
+// space so that a line of glyphs (textWidth) is stretched to fill its cell.
+// slackPts is (cellWidth - textWidth) in points, spread over gapCount gaps.
+// TJ numbers are thousandths of glyph space, scaled by font size, and are
+// SUBTRACTED from the pen advance, so a negative number widens the gap.
+// Returns 0 when there is nothing to distribute.
+func justifyAdjustment(slackPts float64, gapCount int, fontSize float64) int {
+	if gapCount <= 0 || slackPts <= 0 || fontSize <= 0 {
+		return 0
+	}
+	perGap := slackPts / float64(gapCount)
+	return int(math.Round(-(perGap * 1000.0 / fontSize)))
+}
+
 func (c *cacheContentText) calTypoAscender() float64 {
 	return convertTypoUnit(float64(c.fontSubset.ttfp.TypoAscender()), c.fontSubset.ttfp.UnitsPerEm(), float64(c.fontSize))
 }

--- a/cache_content_text.go
+++ b/cache_content_text.go
@@ -225,6 +225,23 @@ func (c *cacheContentText) write(w io.Writer, protection *PDFProtection) error {
 	}
 	io.WriteString(w, "[<")
 
+	// justify: distribute leftover width across interior word gaps by emitting
+	// a negative TJ number after each interior space (widening the gap).
+	justify := c.contentType == ContentTypeCell &&
+		c.cellOpt.Align&Justify == Justify &&
+		c.rectangle != nil
+	tjAdjust := 0
+	firstNonSpace, lastNonSpace := -1, -1
+	if justify {
+		slack := c.cellWidthPdfUnit - c.textWidthPdfUnit
+		tjAdjust = justifyAdjustment(slack, interiorSpaceCount(c.text), c.fontSize)
+		if tjAdjust == 0 {
+			justify = false // no slack or no gaps: fall back to left alignment
+		} else {
+			firstNonSpace, lastNonSpace = nonSpaceBounds(c.text)
+		}
+	}
+
 	unitsPerEm := int(c.fontSubset.ttfp.UnitsPerEm())
 	var leftRune rune
 	var leftRuneIndex uint
@@ -247,6 +264,11 @@ func (c *cacheContentText) write(w io.Writer, protection *PDFProtection) error {
 		}
 
 		fmt.Fprintf(w, "%04X", glyphindex)
+
+		if justify && r == ' ' && i > firstNonSpace && i < lastNonSpace {
+			fmt.Fprintf(w, ">%d<", tjAdjust)
+		}
+
 		leftRune = r
 		leftRuneIndex = glyphindex
 	}

--- a/cache_content_text.go
+++ b/cache_content_text.go
@@ -126,6 +126,16 @@ func interiorSpaceCount(text string) int {
 	return count
 }
 
+// lineAlign returns the alignment to apply to a single wrapped line. The last
+// line of a justified paragraph is left-aligned (standard typographic
+// behavior) rather than stretched; all other cases are returned unchanged.
+func lineAlign(align int, isLastLine bool) int {
+	if isLastLine && align&Justify == Justify {
+		return align&^Justify | Left
+	}
+	return align
+}
+
 func (c *cacheContentText) calTypoAscender() float64 {
 	return convertTypoUnit(float64(c.fontSubset.ttfp.TypoAscender()), c.fontSubset.ttfp.UnitsPerEm(), float64(c.fontSize))
 }

--- a/cache_content_text.go
+++ b/cache_content_text.go
@@ -94,6 +94,38 @@ func justifyAdjustment(slackPts float64, gapCount int, fontSize float64) int {
 	return int(math.Round(-(perGap * 1000.0 / fontSize)))
 }
 
+// nonSpaceBounds returns the byte index of the first and last non-space
+// (' ') rune in text, or (-1, -1) when text is empty or all spaces.
+func nonSpaceBounds(text string) (first, last int) {
+	first, last = -1, -1
+	for i, r := range text {
+		if r != ' ' {
+			if first < 0 {
+				first = i
+			}
+			last = i
+		}
+	}
+	return first, last
+}
+
+// interiorSpaceCount counts the ' ' runes that have a non-space rune both
+// before and after them (i.e. word gaps eligible for justification, with
+// leading/trailing spaces excluded).
+func interiorSpaceCount(text string) int {
+	first, last := nonSpaceBounds(text)
+	if first < 0 {
+		return 0
+	}
+	count := 0
+	for i, r := range text {
+		if r == ' ' && i > first && i < last {
+			count++
+		}
+	}
+	return count
+}
+
 func (c *cacheContentText) calTypoAscender() float64 {
 	return convertTypoUnit(float64(c.fontSubset.ttfp.TypoAscender()), c.fontSubset.ttfp.UnitsPerEm(), float64(c.fontSize))
 }

--- a/cell_option.go
+++ b/cell_option.go
@@ -12,12 +12,14 @@ const Bottom = 1 //000001
 const Center = 16 //010000
 // Middle middle
 const Middle = 32 //100000
+// Justify justify (stretch a line to fill the full cell width)
+const Justify = 64 //1000000
 // AllBorders allborders
 const AllBorders = 15 //001111
 
 // CellOption cell option
 type CellOption struct {
-	Align                  int //Allows to align the text. Possible values are: Left,Center,Right,Top,Bottom,Middle
+	Align                  int //Allows to align the text. Possible values are: Left,Center,Right,Justify,Top,Bottom,Middle
 	Border                 int //Indicates if borders must be drawn around the cell. Possible values are: Left, Top, Right, Bottom, ALL
 	Float                  int //Indicates where the current position should go after the call. Possible values are: Right, Bottom
 	Transparency           *Transparency

--- a/gopdf.go
+++ b/gopdf.go
@@ -1309,8 +1309,11 @@ func (gp *GoPdf) MultiCellWithOption(rectangle *Rect, text string, opt CellOptio
 		startHeight = rectangle.H - (lineHeight+1.5)*float64(shiftLines)
 	}
 
-	for _, text := range textSplits {
-		gp.CellWithOption(&Rect{W: rectangle.W, H: startHeight}, string(text), opt)
+	lastLine := len(textSplits) - 1
+	for i, text := range textSplits {
+		lineOpt := opt
+		lineOpt.Align = lineAlign(opt.Align, i == lastLine)
+		gp.CellWithOption(&Rect{W: rectangle.W, H: startHeight}, string(text), lineOpt)
 		gp.Br(lineHeight)
 		gp.SetX(x)
 	}

--- a/justify_test.go
+++ b/justify_test.go
@@ -201,3 +201,55 @@ func TestJustifyMultiCellLastLineNotStretched(t *testing.T) {
 		t.Fatalf("last (only) line must not be justified; adjustment delta = %d, want 0", got)
 	}
 }
+
+// renderKernedCell renders a single cell using the Ubuntu font (which has a
+// legacy `kern` table, unlike LiberationSerif) with kerning optionally enabled,
+// and returns the raw, uncompressed content bytes.
+func renderKernedCell(t *testing.T, text string, align int, useKerning bool) []byte {
+	t.Helper()
+	pdf := &GoPdf{}
+	pdf.Start(Config{PageSize: *PageSizeA4})
+	pdf.AddPage()
+	if err := pdf.AddTTFFontWithOption("Ubuntu-L",
+		"./examples/outline_example/Ubuntu-L.ttf", TtfOption{UseKerning: useKerning}); err != nil {
+		t.Fatal(err)
+	}
+	if err := pdf.SetFont("Ubuntu-L", "", 14); err != nil {
+		t.Fatal(err)
+	}
+	pdf.SetNoCompression()
+	pdf.SetXY(20, 40)
+	if err := pdf.CellWithOption(&Rect{W: 500, H: 20}, text,
+		CellOption{Align: align | Top}); err != nil {
+		t.Fatal(err)
+	}
+	b, err := pdf.GetBytesPdfReturnErr()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// Justify must work when kerning is enabled: both mechanisms emit position
+// numbers into the same TJ array. This verifies (1) kerning genuinely alters
+// the output for this font/text, and (2) enabling justify on top of kerning
+// adds exactly one adjustment per interior space — i.e. justify coexists with
+// kerning and is unaffected by it.
+func TestJustifyCoexistsWithKerning(t *testing.T) {
+	const text = "AVA WAV YAV" // capital pairs that kern in Ubuntu; 2 interior spaces
+
+	leftNoKern := renderKernedCell(t, text, Left, false)
+	leftKern := renderKernedCell(t, text, Left, true)
+	justifyKern := renderKernedCell(t, text, Justify, true)
+
+	// (1) Kerning must actually be active for this font/text.
+	if bytes.Equal(leftNoKern, leftKern) {
+		t.Fatal("kerning enabled produced identical output to kerning disabled; " +
+			"the font/text no longer exercises kerning, so this test is vacuous")
+	}
+
+	// (2) Justify adds exactly its interior-space adjustments on top of kerning.
+	if got, want := countAdjust(justifyKern)-countAdjust(leftKern), interiorSpaceCount(text); got != want {
+		t.Fatalf("with kerning enabled, justify adjustment delta = %d, want %d", got, want)
+	}
+}

--- a/justify_test.go
+++ b/justify_test.go
@@ -59,3 +59,21 @@ func TestInteriorSpaceCount(t *testing.T) {
 		}
 	}
 }
+
+func TestLineAlign(t *testing.T) {
+	if got := lineAlign(Justify, false); got != Justify {
+		t.Fatalf("non-last justify line = %d, want %d (Justify)", got, Justify)
+	}
+	if got := lineAlign(Justify, true); got != Left {
+		t.Fatalf("last justify line = %d, want %d (Left)", got, Left)
+	}
+	if got := lineAlign(Justify|Top, true); got != Left|Top {
+		t.Fatalf("last justify+top line = %d, want %d (Left|Top)", got, Left|Top)
+	}
+	if got := lineAlign(Center, true); got != Center {
+		t.Fatalf("last center line = %d, want %d (unchanged)", got, Center)
+	}
+	if got := lineAlign(Left, false); got != Left {
+		t.Fatalf("non-last left line = %d, want %d (unchanged)", got, Left)
+	}
+}

--- a/justify_test.go
+++ b/justify_test.go
@@ -27,3 +27,35 @@ func TestJustifyAdjustment(t *testing.T) {
 		})
 	}
 }
+
+func TestNonSpaceBounds(t *testing.T) {
+	first, last := nonSpaceBounds("  hi  ")
+	if first != 2 || last != 3 {
+		t.Fatalf("nonSpaceBounds = (%d,%d), want (2,3)", first, last)
+	}
+	if f, l := nonSpaceBounds("   "); f != -1 || l != -1 {
+		t.Fatalf("all-spaces bounds = (%d,%d), want (-1,-1)", f, l)
+	}
+	if f, l := nonSpaceBounds(""); f != -1 || l != -1 {
+		t.Fatalf("empty bounds = (%d,%d), want (-1,-1)", f, l)
+	}
+}
+
+func TestInteriorSpaceCount(t *testing.T) {
+	tests := []struct {
+		text string
+		want int
+	}{
+		{"hello world", 1},
+		{"a b c", 2},
+		{"  hello   world  ", 3}, // 3 interior spaces; leading/trailing excluded
+		{"word", 0},
+		{"", 0},
+		{"   ", 0},
+	}
+	for _, tt := range tests {
+		if got := interiorSpaceCount(tt.text); got != tt.want {
+			t.Fatalf("interiorSpaceCount(%q) = %d, want %d", tt.text, got, tt.want)
+		}
+	}
+}

--- a/justify_test.go
+++ b/justify_test.go
@@ -135,3 +135,69 @@ func TestJustifyCellInjectsAdjustments(t *testing.T) {
 		t.Fatalf("justify adjustment count delta = %d, want 3", got)
 	}
 }
+
+// A paragraph that wraps to multiple lines should have justify adjustments
+// (on all but the last line).
+func TestJustifyMultiCellWraps(t *testing.T) {
+	const text = "the quick brown fox jumps over the lazy dog again and again"
+
+	justified := newJustifyTestPDF(t)
+	justified.SetXY(20, 40)
+	if err := justified.MultiCellWithOption(&Rect{W: 150, H: 400}, text,
+		CellOption{Align: Justify}); err != nil {
+		t.Fatal(err)
+	}
+	jb, err := justified.GetBytesPdfReturnErr()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	left := newJustifyTestPDF(t)
+	left.SetXY(20, 40)
+	if err := left.MultiCellWithOption(&Rect{W: 150, H: 400}, text,
+		CellOption{Align: Left}); err != nil {
+		t.Fatal(err)
+	}
+	lb, err := left.GetBytesPdfReturnErr()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if countAdjust(jb)-countAdjust(lb) <= 0 {
+		t.Fatalf("expected justify adjustments in a wrapped paragraph, got delta %d",
+			countAdjust(jb)-countAdjust(lb))
+	}
+}
+
+// The last line of a justified paragraph is left-aligned. When the whole text
+// fits on ONE line, that sole line is the last line, so MultiCell must NOT
+// justify it (unlike CellWithOption, which does).
+func TestJustifyMultiCellLastLineNotStretched(t *testing.T) {
+	const text = "quick brown" // fits on one line in a 400-wide rect
+
+	justified := newJustifyTestPDF(t)
+	justified.SetXY(20, 40)
+	if err := justified.MultiCellWithOption(&Rect{W: 400, H: 100}, text,
+		CellOption{Align: Justify}); err != nil {
+		t.Fatal(err)
+	}
+	jb, err := justified.GetBytesPdfReturnErr()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	left := newJustifyTestPDF(t)
+	left.SetXY(20, 40)
+	if err := left.MultiCellWithOption(&Rect{W: 400, H: 100}, text,
+		CellOption{Align: Left}); err != nil {
+		t.Fatal(err)
+	}
+	lb, err := left.GetBytesPdfReturnErr()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := countAdjust(jb) - countAdjust(lb); got != 0 {
+		t.Fatalf("last (only) line must not be justified; adjustment delta = %d, want 0", got)
+	}
+}

--- a/justify_test.go
+++ b/justify_test.go
@@ -1,6 +1,9 @@
 package gopdf
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 func TestJustifyAdjustment(t *testing.T) {
 	tests := []struct {
@@ -75,5 +78,60 @@ func TestLineAlign(t *testing.T) {
 	}
 	if got := lineAlign(Left, false); got != Left {
 		t.Fatalf("non-last left line = %d, want %d (unchanged)", got, Left)
+	}
+}
+
+// newJustifyTestPDF returns a started A4 PDF with a font loaded and content
+// compression disabled so the content stream can be inspected as raw bytes.
+func newJustifyTestPDF(t *testing.T) *GoPdf {
+	t.Helper()
+	pdf := &GoPdf{}
+	pdf.Start(Config{PageSize: *PageSizeA4})
+	pdf.AddPage()
+	if err := pdf.AddTTFFont("LiberationSerif-Regular", "./test/res/LiberationSerif-Regular.ttf"); err != nil {
+		t.Fatal(err)
+	}
+	if err := pdf.SetFont("LiberationSerif-Regular", "", 14); err != nil {
+		t.Fatal(err)
+	}
+	pdf.SetNoCompression()
+	return pdf
+}
+
+// countAdjust counts justify/kerning adjustment markers ">-" in a content
+// stream. Justify numbers are always negative, so ">-" marks each injected gap.
+func countAdjust(b []byte) int {
+	return bytes.Count(b, []byte(">-"))
+}
+
+func TestJustifyCellInjectsAdjustments(t *testing.T) {
+	const text = "the quick brown fox" // 3 interior spaces
+
+	justified := newJustifyTestPDF(t)
+	justified.SetXY(20, 40)
+	if err := justified.CellWithOption(&Rect{W: 400, H: 20}, text,
+		CellOption{Align: Justify | Top}); err != nil {
+		t.Fatal(err)
+	}
+	jb, err := justified.GetBytesPdfReturnErr()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	left := newJustifyTestPDF(t)
+	left.SetXY(20, 40)
+	if err := left.CellWithOption(&Rect{W: 400, H: 20}, text,
+		CellOption{Align: Left | Top}); err != nil {
+		t.Fatal(err)
+	}
+	lb, err := left.GetBytesPdfReturnErr()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The only systematic difference between the two documents is the injected
+	// justify adjustments — one per interior space.
+	if got := countAdjust(jb) - countAdjust(lb); got != 3 {
+		t.Fatalf("justify adjustment count delta = %d, want 3", got)
 	}
 }

--- a/justify_test.go
+++ b/justify_test.go
@@ -1,0 +1,29 @@
+package gopdf
+
+import "testing"
+
+func TestJustifyAdjustment(t *testing.T) {
+	tests := []struct {
+		name     string
+		slack    float64
+		gapCount int
+		fontSize float64
+		want     int
+	}{
+		{"zero gaps", 30, 0, 10, 0},
+		{"zero slack", 0, 3, 10, 0},
+		{"negative slack", -5, 3, 10, 0},
+		{"zero font size", 30, 3, 0, 0},
+		{"even distribution", 30, 3, 10, -1000},   // 10pt/gap -> -(10*1000/10)
+		{"rounded distribution", 10, 3, 12, -278}, // 3.3333pt/gap -> -(277.78) rounded
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := justifyAdjustment(tt.slack, tt.gapCount, tt.fontSize)
+			if got != tt.want {
+				t.Fatalf("justifyAdjustment(%v,%d,%v) = %d, want %d",
+					tt.slack, tt.gapCount, tt.fontSize, got, tt.want)
+			}
+		})
+	}
+}

--- a/justify_visual_demo_test.go
+++ b/justify_visual_demo_test.go
@@ -1,0 +1,95 @@
+package gopdf
+
+import (
+	"os"
+	"testing"
+)
+
+// TestJustifyVisualDemo renders the alignment options into a single PDF so the
+// justify behaviour can be checked visually. Each sample sits in a bordered box:
+// a justified line is flush against both inner edges, a justified paragraph has
+// every line flush except the last (which stays left-aligned), and the graceful
+// fallbacks (a line with no spaces, or one that overflows) stay left-aligned.
+//
+// It writes ./test/out/justify_demo.pdf. Run it on its own with:
+//
+//	go test -run TestJustifyVisualDemo
+func TestJustifyVisualDemo(t *testing.T) {
+	if err := os.MkdirAll("./test/out", 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	pdf := &GoPdf{}
+	pdf.Start(Config{PageSize: *PageSizeA4})
+	pdf.AddPage()
+	if err := pdf.AddTTFFont("LiberationSerif-Regular", "./test/res/LiberationSerif-Regular.ttf"); err != nil {
+		t.Fatal(err)
+	}
+	if err := pdf.SetFont("LiberationSerif-Regular", "", 14); err != nil {
+		t.Fatal(err)
+	}
+
+	const (
+		labelX = 40.0
+		boxX   = 200.0
+		boxW   = 340.0
+		lineH  = 20.0
+	)
+	// Wrap paragraphs on spaces (word boundaries) instead of the mid-word default.
+	wordBreak := &BreakOption{Mode: BreakModeIndicatorSensitive, BreakIndicator: ' '}
+
+	label := func(y float64, s string) {
+		pdf.SetXY(labelX, y)
+		pdf.Cell(nil, s)
+	}
+	// line draws a single line of text in a bordered box.
+	line := func(y float64, text string, align int) {
+		pdf.SetXY(boxX, y)
+		if err := pdf.CellWithOption(&Rect{W: boxW, H: lineH}, text,
+			CellOption{Align: align | Top, Border: AllBorders}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// paragraph wraps text over multiple lines and draws ONE border around the
+	// whole block. MultiCell would redraw a full box for every line (stacking
+	// overlapping borders), so we render without a border and box it ourselves.
+	paragraph := func(y float64, text string, align int) {
+		pdf.SetXY(boxX, y)
+		if err := pdf.MultiCellWithOption(&Rect{W: boxW, H: lineH}, text,
+			CellOption{Align: align, BreakOption: wordBreak}); err != nil {
+			t.Fatal(err)
+		}
+		pdf.RectFromUpperLeft(boxX, y, boxW, pdf.GetY()-y)
+	}
+	row := func(y *float64, name, text string, align int) {
+		label(*y, name)
+		line(*y, text, align)
+		*y += 34
+	}
+
+	const sample = "the quick brown fox jumps over"
+	const para = "the quick brown fox jumps over the lazy dog while the sun sets " +
+		"slowly over the quiet western hills as a gentle breeze drifts across the " +
+		"meadow carrying the faint scent of pine and distant rain this evening"
+
+	y := 40.0
+	row(&y, "Left", sample, Left)
+	row(&y, "Center", sample, Center)
+	row(&y, "Right", sample, Right)
+	row(&y, "Justify (single line)", sample, Justify)
+	y += 10
+
+	label(y, "Justify (paragraph)")
+	paragraph(y, para, Justify)
+	y = pdf.GetY() + 26
+
+	row(&y, "Fallback: no spaces", "supercalifragilistic", Justify)
+	label(y, "Fallback: overflow")
+	line(y, "this single line of text is far too long to ever fit inside the width of this box", Justify)
+
+	out := "./test/out/justify_demo.pdf"
+	if err := pdf.WritePdf(out); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("wrote %s", out)
+}


### PR DESCRIPTION
## Summary

Adds a `Justify` horizontal alignment so text can be stretched to fill the full
cell width, flush on both edges. It works for a single line via `CellWithOption`
and for wrapped paragraphs via `MultiCellWithOption`, where every line is
justified except the last line of the paragraph (standard word-processor
behaviour). The change is purely additive — no exported signature changes, and
existing output is byte-for-byte unchanged unless a caller opts in with
`Justify`.

```go
// Single justified line
pdf.CellWithOption(&gopdf.Rect{W: 400, H: 20}, text,
    gopdf.CellOption{Align: gopdf.Justify | gopdf.Top})

// Justified paragraph (last line left-aligned automatically)
pdf.MultiCellWithOption(&gopdf.Rect{W: 400, H: 200}, paragraph,
    gopdf.CellOption{Align: gopdf.Justify})
```

## How it works

`gopdf` renders text as subset (composite/CID) font glyph arrays,
`[<hex...>] TJ`. Because of that the PDF `Tw` word-spacing operator is unusable
here — `Tw` only affects the single-byte code 32, which never appears in a
composite-font glyph array. Instead, justification distributes the leftover
width by injecting a negative position-adjustment number into the `TJ` array
after each interior space, widening the gap. This is the exact same channel the
code already uses for kerning, so the two coexist naturally.

- `Justify = 64` is the next free alignment bit — no bitmask collision.
- The per-gap math lives in a small pure helper, `justifyAdjustment`, that is
  unit-tested in isolation.
- Only **interior** spaces receive stretch; leading/trailing spaces left on a
  wrapped line are excluded.
- `calX()` needs no change: bit 64 doesn't match the `Right`/`Center` branches,
  so a justified line already starts flush-left and is stretched rightward.
- Line wrapping is unchanged: `MultiCellWithOption` justifies whatever lines the
  caller's existing `BreakOption` produces, so word-boundary wrapping
  (`BreakModeIndicatorSensitive`) works with justify exactly as with any other
  alignment.

## Graceful fallback

A justified cell falls back to today's left-aligned output (never compressed or
corrupted) when any of these hold:

- the line has no interior spaces (a single long word / spaceless script),
- the text exactly fits or overflows the cell (`slack <= 0`),
- the cell has no target width (`rectangle == nil`).

## Tests

`justify_test.go` adds:

- Unit tests for the pure helpers (`justifyAdjustment`, interior-gap detection,
  the last-line policy).
- Integration tests that render real PDFs and assert the injected adjustments
  appear once per interior space, that a wrapped paragraph is justified, and
  that the last line of a `MultiCell` paragraph is **not** stretched.
- An integration test that enables kerning and confirms justify coexists with
  it — kerning genuinely alters the output, and justify then adds exactly its
  interior-space adjustments on top, unaffected by the kerning numbers in the
  same `TJ` array.

`justify_visual_demo_test.go` renders every alignment plus the fallback cases
into `./test/out/justify_demo.pdf` for manual visual confirmation (the generated
PDF is gitignored). The alignments were verified visually in addition to the
automated checks.

Docs: a "Justified text" section was added to the README.
